### PR TITLE
Add Slack integration for running sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,14 +93,21 @@ Simply visit [sprintjam.co.uk](https://sprintjam.co.uk) and start creating rooms
    LINEAR_OAUTH_CLIENT_ID=your-linear-client-id
    LINEAR_OAUTH_CLIENT_SECRET=your-linear-client-secret
    LINEAR_OAUTH_REDIRECT_URI=https://your-domain.com/api/linear/oauth/callback
+
+   # Optional: Slack OAuth
+   SLACK_OAUTH_CLIENT_ID=your-slack-client-id
+   SLACK_OAUTH_CLIENT_SECRET=your-slack-client-secret
+   SLACK_OAUTH_REDIRECT_URI=https://your-domain.com/api/slack/oauth/callback
    ```
 
    **To enable an external provider:**
 
-   a. Create an OAuth 2.0 app with the provider (Atlassian Developer Console for Jira; Linear Developer Settings for Linear) and set the redirect URI to match the value above.  
-   b. Add required scopes (only required for Jira: `read:jira-work`, `write:jira-work`, `read:jira-user`, `offline_access`).  
-   c. Copy the client ID/secret into the corresponding env vars.  
-   d. In a room, open Settings → Other Options → External Provider and connect Jira or Linear.
+   a. Create an OAuth 2.0 app with the provider (Atlassian Developer Console for Jira; Linear Developer Settings for Linear; Slack API Apps for Slack) and set the redirect URI to match the value above.
+   b. Add required scopes:
+      - Jira: `read:jira-work`, `write:jira-work`, `read:jira-user`, `offline_access`
+      - Slack: `chat:write`, `chat:write.public`, `channels:read`, `groups:read`, `identify` (user scope)
+   c. Copy the client ID/secret into the corresponding env vars.
+   d. In a room, open Settings → Other Options → External Provider and connect Jira, Linear, or Slack.
 
 4. **Deploy to Cloudflare**
    ```bash

--- a/api/controllers/slack-controller.ts
+++ b/api/controllers/slack-controller.ts
@@ -1,0 +1,291 @@
+import type {
+  Request as CfRequest,
+  Response as CfResponse,
+} from "@cloudflare/workers-types";
+
+import type { Env, RoomData } from "../types";
+import { jsonError } from "../utils/http";
+import { getRoomStub } from '../utils/room';
+import {
+  postSlackMessage,
+  formatVotingResultsForSlack,
+  formatSessionStartForSlack,
+} from '../services/slack-service';
+
+function jsonResponse(payload: unknown, status = 200): CfResponse {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  }) as unknown as CfResponse;
+}
+
+async function validateSession(
+  env: Env,
+  roomKey: string,
+  userName: string,
+  sessionToken?: string | null
+) {
+  if (!sessionToken) {
+    throw new Error('Missing session token');
+  }
+
+  const roomObject = getRoomStub(env, roomKey);
+  const response = await roomObject.fetch(
+    new Request('https://dummy/session/validate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: userName, sessionToken }),
+    }) as unknown as CfRequest
+  );
+
+  if (!response.ok) {
+    const error = await response.json<{
+      error?: string;
+    }>();
+    throw new Error(error.error || 'Invalid session');
+  }
+}
+
+async function getSlackCredentials(env: Env, roomKey: string) {
+  const roomObject = getRoomStub(env, roomKey);
+  const response = await roomObject.fetch(
+    new Request('https://dummy/slack/oauth/credentials', {
+      method: 'GET',
+    }) as unknown as CfRequest
+  );
+
+  if (!response.ok) {
+    return null;
+  }
+
+  return await response.json<{
+    id: number;
+    roomKey: string;
+    accessToken: string;
+    refreshToken: string | null;
+    tokenType: string;
+    expiresAt: number;
+    scope: string | null;
+    slackTeamId: string | null;
+    slackTeamName: string | null;
+    slackChannelId: string | null;
+    slackChannelName: string | null;
+    slackUserId: string | null;
+    slackUserName: string | null;
+    authorizedBy: string;
+    createdAt: number;
+    updatedAt: number;
+  }>();
+}
+
+async function updateSlackTokens(
+  env: Env,
+  roomKey: string,
+  accessToken: string,
+  refreshToken: string,
+  expiresAt: number
+) {
+  const roomObject = getRoomStub(env, roomKey);
+  await roomObject.fetch(
+    new Request('https://dummy/slack/oauth/refresh', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ accessToken, refreshToken, expiresAt }),
+    }) as unknown as CfRequest
+  );
+}
+
+export async function postSessionResultsController(
+  request: CfRequest,
+  env: Env
+): Promise<CfResponse> {
+  const body = await request.json<{
+    roomKey?: string;
+    userName?: string;
+    sessionToken?: string;
+    roomData?: RoomData;
+  }>();
+
+  const roomKey = body?.roomKey;
+  const userName = body?.userName;
+  const sessionToken = body?.sessionToken;
+  const roomData = body?.roomData;
+
+  if (!roomKey || !userName || !roomData) {
+    return jsonError('Room key, user name, and room data are required');
+  }
+
+  try {
+    await validateSession(env, roomKey, userName, sessionToken);
+
+    const credentials = await getSlackCredentials(env, roomKey);
+
+    if (!credentials) {
+      return jsonError('Slack not connected', 404);
+    }
+
+    if (!credentials.slackChannelId) {
+      return jsonError('No Slack channel configured', 400);
+    }
+
+    const clientId = env.SLACK_OAUTH_CLIENT_ID;
+    const clientSecret = env.SLACK_OAUTH_CLIENT_SECRET;
+
+    if (!clientId || !clientSecret) {
+      return jsonError('Slack OAuth not configured', 500);
+    }
+
+    const message = formatVotingResultsForSlack(roomData);
+    message.channel = credentials.slackChannelId;
+
+    const result = await postSlackMessage(
+      credentials,
+      message,
+      async (accessToken, refreshToken, expiresAt) => {
+        await updateSlackTokens(env, roomKey, accessToken, refreshToken, expiresAt);
+      },
+      clientId,
+      clientSecret
+    );
+
+    return jsonResponse({
+      success: true,
+      messageTs: result.ts,
+      channel: result.channel,
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Failed to post to Slack';
+    return jsonError(message, 500);
+  }
+}
+
+export async function postSessionStartController(
+  request: CfRequest,
+  env: Env
+): Promise<CfResponse> {
+  const body = await request.json<{
+    roomKey?: string;
+    userName?: string;
+    sessionToken?: string;
+    roomData?: RoomData;
+  }>();
+
+  const roomKey = body?.roomKey;
+  const userName = body?.userName;
+  const sessionToken = body?.sessionToken;
+  const roomData = body?.roomData;
+
+  if (!roomKey || !userName || !roomData) {
+    return jsonError('Room key, user name, and room data are required');
+  }
+
+  try {
+    await validateSession(env, roomKey, userName, sessionToken);
+
+    const credentials = await getSlackCredentials(env, roomKey);
+
+    if (!credentials) {
+      return jsonError('Slack not connected', 404);
+    }
+
+    if (!credentials.slackChannelId) {
+      return jsonError('No Slack channel configured', 400);
+    }
+
+    const clientId = env.SLACK_OAUTH_CLIENT_ID;
+    const clientSecret = env.SLACK_OAUTH_CLIENT_SECRET;
+
+    if (!clientId || !clientSecret) {
+      return jsonError('Slack OAuth not configured', 500);
+    }
+
+    const message = formatSessionStartForSlack(roomData);
+    message.channel = credentials.slackChannelId;
+
+    const result = await postSlackMessage(
+      credentials,
+      message,
+      async (accessToken, refreshToken, expiresAt) => {
+        await updateSlackTokens(env, roomKey, accessToken, refreshToken, expiresAt);
+      },
+      clientId,
+      clientSecret
+    );
+
+    return jsonResponse({
+      success: true,
+      messageTs: result.ts,
+      channel: result.channel,
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Failed to post to Slack';
+    return jsonError(message, 500);
+  }
+}
+
+export async function postCustomMessageController(
+  request: CfRequest,
+  env: Env
+): Promise<CfResponse> {
+  const body = await request.json<{
+    roomKey?: string;
+    userName?: string;
+    sessionToken?: string;
+    text: string;
+  }>();
+
+  const roomKey = body?.roomKey;
+  const userName = body?.userName;
+  const sessionToken = body?.sessionToken;
+  const text = body?.text;
+
+  if (!roomKey || !userName || !text) {
+    return jsonError('Room key, user name, and text are required');
+  }
+
+  try {
+    await validateSession(env, roomKey, userName, sessionToken);
+
+    const credentials = await getSlackCredentials(env, roomKey);
+
+    if (!credentials) {
+      return jsonError('Slack not connected', 404);
+    }
+
+    if (!credentials.slackChannelId) {
+      return jsonError('No Slack channel configured', 400);
+    }
+
+    const clientId = env.SLACK_OAUTH_CLIENT_ID;
+    const clientSecret = env.SLACK_OAUTH_CLIENT_SECRET;
+
+    if (!clientId || !clientSecret) {
+      return jsonError('Slack OAuth not configured', 500);
+    }
+
+    const result = await postSlackMessage(
+      credentials,
+      {
+        channel: credentials.slackChannelId,
+        text,
+      },
+      async (accessToken, refreshToken, expiresAt) => {
+        await updateSlackTokens(env, roomKey, accessToken, refreshToken, expiresAt);
+      },
+      clientId,
+      clientSecret
+    );
+
+    return jsonResponse({
+      success: true,
+      messageTs: result.ts,
+      channel: result.channel,
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Failed to post to Slack';
+    return jsonError(message, 500);
+  }
+}

--- a/api/controllers/slack-oauth-controller.ts
+++ b/api/controllers/slack-oauth-controller.ts
@@ -1,0 +1,354 @@
+import type {
+  Request as CfRequest,
+  Response as CfResponse,
+} from "@cloudflare/workers-types";
+
+import type { Env } from "../types";
+import { jsonError } from "../utils/http";
+import { getRoomStub } from '../utils/room';
+import {
+  getSlackTeamInfo,
+  getSlackUserInfo,
+} from '../services/slack-service';
+import { escapeHtml, signState, verifyState } from "../utils/security";
+
+function jsonResponse(payload: unknown, status = 200): CfResponse {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  }) as unknown as CfResponse;
+}
+
+async function validateSession(
+  env: Env,
+  roomKey: string,
+  userName: string,
+  sessionToken?: string | null
+) {
+  if (!sessionToken) {
+    throw new Error('Missing session token');
+  }
+
+  const roomObject = getRoomStub(env, roomKey);
+  const response = await roomObject.fetch(
+    new Request('https://dummy/session/validate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: userName, sessionToken }),
+    }) as unknown as CfRequest
+  );
+
+  if (!response.ok) {
+    const error = await response.json<{
+      error?: string;
+    }>();
+    throw new Error(error.error || 'Invalid session');
+  }
+}
+
+export async function initiateSlackOAuthController(
+  request: CfRequest,
+  env: Env
+): Promise<CfResponse> {
+  const body = await request.json<{
+    roomKey?: string;
+    userName?: string;
+    sessionToken?: string;
+  }>();
+
+  const roomKey = body?.roomKey;
+  const userName = body?.userName;
+  const sessionToken = body?.sessionToken;
+
+  if (!roomKey || !userName) {
+    return jsonError('Room key and user name are required');
+  }
+
+  try {
+    await validateSession(env, roomKey, userName, sessionToken);
+
+    const clientId = env.SLACK_OAUTH_CLIENT_ID;
+    const redirectUri =
+      env.SLACK_OAUTH_REDIRECT_URI ||
+      'https://sprintjam.co.uk/api/slack/oauth/callback';
+
+    if (!clientId || !env.SLACK_OAUTH_CLIENT_SECRET) {
+      return jsonError(
+        'OAuth not configured. Please contact administrator.',
+        500
+      );
+    }
+
+    const state = await signState(
+      { roomKey, userName, nonce: crypto.randomUUID() },
+      env.SLACK_OAUTH_CLIENT_SECRET
+    );
+
+    const authUrl = new URL('https://slack.com/oauth/v2/authorize');
+    authUrl.searchParams.set('client_id', clientId);
+    authUrl.searchParams.set('redirect_uri', redirectUri);
+    authUrl.searchParams.set('scope', 'chat:write,chat:write.public,channels:read,groups:read');
+    authUrl.searchParams.set('state', state);
+    authUrl.searchParams.set('user_scope', 'identify');
+
+    return jsonResponse({ authorizationUrl: authUrl.toString(), state });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Failed to initiate OAuth';
+    return jsonError(message, 500);
+  }
+}
+
+export async function handleSlackOAuthCallbackController(
+  url: URL,
+  env: Env
+): Promise<CfResponse> {
+  const code = url.searchParams.get('code');
+  const state = url.searchParams.get('state');
+  const error = url.searchParams.get('error');
+
+  if (error) {
+    return new Response(
+      `<html><body><h1>OAuth Error</h1><p>${escapeHtml(error)}</p><script>window.close();</script></body></html>`,
+      { status: 400, headers: { 'Content-Type': 'text/html' } }
+    ) as unknown as CfResponse;
+  }
+
+  if (!code || !state) {
+    return new Response(
+      `<html><body><h1>OAuth Error</h1><p>Missing code or state</p><script>window.close();</script></body></html>`,
+      { status: 400, headers: { 'Content-Type': 'text/html' } }
+    ) as unknown as CfResponse;
+  }
+
+  try {
+    const clientId = env.SLACK_OAUTH_CLIENT_ID;
+    const clientSecret = env.SLACK_OAUTH_CLIENT_SECRET;
+    const redirectUri =
+      env.SLACK_OAUTH_REDIRECT_URI ||
+      'https://sprintjam.co.uk/api/slack/oauth/callback';
+
+    if (!clientId || !clientSecret) {
+      return new Response(
+        `<html><body><h1>OAuth Error</h1><p>OAuth not configured</p><script>window.close();</script></body></html>`,
+        { status: 500, headers: { 'Content-Type': 'text/html' } }
+      ) as unknown as CfResponse;
+    }
+
+    const stateData = (await verifyState(state, clientSecret)) as {
+      roomKey: string;
+      userName: string;
+      nonce: string;
+    };
+    const { roomKey, userName } = stateData;
+
+    const tokenResponse = await fetch(
+      'https://slack.com/api/oauth.v2.access',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded',
+        },
+        body: new URLSearchParams({
+          client_id: clientId,
+          client_secret: clientSecret,
+          code,
+          redirect_uri: redirectUri,
+        }).toString(),
+      }
+    );
+
+    if (!tokenResponse.ok) {
+      const errorData = await tokenResponse.text();
+      console.error('Token exchange failed:', errorData);
+      return new Response(
+        `<html><body><h1>OAuth Error</h1><p>Failed to exchange code for token</p><script>window.close();</script></body></html>`,
+        { status: 500, headers: { 'Content-Type': 'text/html' } }
+      ) as unknown as CfResponse;
+    }
+
+    const tokenData = await tokenResponse.json<{
+      ok: boolean;
+      access_token: string;
+      refresh_token?: string;
+      expires_in?: number;
+      token_type: string;
+      scope?: string;
+      team?: {
+        id: string;
+        name: string;
+      };
+      authed_user?: {
+        id: string;
+        access_token?: string;
+      };
+      error?: string;
+    }>();
+
+    if (!tokenData.ok) {
+      console.error('Token exchange failed:', tokenData.error);
+      return new Response(
+        `<html><body><h1>OAuth Error</h1><p>${escapeHtml(tokenData.error || 'Unknown error')}</p><script>window.close();</script></body></html>`,
+        { status: 500, headers: { 'Content-Type': 'text/html' } }
+      ) as unknown as CfResponse;
+    }
+
+    let slackTeamId: string | null = null;
+    let slackTeamName: string | null = null;
+    if (tokenData.team) {
+      slackTeamId = tokenData.team.id;
+      slackTeamName = tokenData.team.name;
+    } else {
+      try {
+        const team = await getSlackTeamInfo(tokenData.access_token);
+        slackTeamId = team.id;
+        slackTeamName = team.name;
+      } catch (teamError) {
+        console.error('Failed to fetch Slack team:', teamError);
+      }
+    }
+
+    let slackUserId: string | null = null;
+    let slackUserName: string | null = null;
+    if (tokenData.authed_user) {
+      slackUserId = tokenData.authed_user.id;
+    }
+
+    try {
+      const user = await getSlackUserInfo(tokenData.access_token);
+      slackUserId = user.id;
+      slackUserName = user.name;
+    } catch (userError) {
+      console.error('Failed to fetch Slack user:', userError);
+    }
+
+    const roomObject = getRoomStub(env, roomKey);
+    const saveResponse = await roomObject.fetch(
+      new Request('https://dummy/slack/oauth/save', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          accessToken: tokenData.access_token,
+          refreshToken: tokenData.refresh_token || null,
+          tokenType: tokenData.token_type,
+          expiresAt: tokenData.expires_in
+            ? Date.now() + tokenData.expires_in * 1000
+            : Date.now() + (365 * 24 * 60 * 60 * 1000), // Default to 1 year if no expiry
+          scope: tokenData.scope || null,
+          slackTeamId,
+          slackTeamName,
+          slackUserId,
+          slackUserName,
+          authorizedBy: userName,
+        }),
+      }) as unknown as CfRequest
+    );
+
+    if (!saveResponse.ok) {
+      return new Response(
+        `<html><body><h1>OAuth Error</h1><p>Failed to save credentials</p><script>window.close();</script></body></html>`,
+        { status: 500, headers: { 'Content-Type': 'text/html' } }
+      ) as unknown as CfResponse;
+    }
+
+    return new Response(
+      `<html><body><h1>Success!</h1><p>Slack connected successfully. You can close this window.</p><script>window.close();</script></body></html>`,
+      { status: 200, headers: { 'Content-Type': 'text/html' } }
+    ) as unknown as CfResponse;
+  } catch (error) {
+    console.error('OAuth callback error:', error);
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return new Response(
+      `<html><body><h1>OAuth Error</h1><p>${escapeHtml(message)}</p><script>window.close();</script></body></html>`,
+      { status: 500, headers: { 'Content-Type': 'text/html' } }
+    ) as unknown as CfResponse;
+  }
+}
+
+export async function getSlackOAuthStatusController(
+  url: URL,
+  env: Env
+): Promise<CfResponse> {
+  const roomKey = url.searchParams.get('roomKey');
+  const userName = url.searchParams.get('userName');
+  const sessionToken = url.searchParams.get('sessionToken');
+
+  if (!roomKey || !userName) {
+    return jsonError('Room key and user name are required');
+  }
+
+  try {
+    await validateSession(env, roomKey, userName, sessionToken);
+
+    const roomObject = getRoomStub(env, roomKey);
+    const statusUrl = new URL('https://dummy/slack/oauth/status');
+    statusUrl.searchParams.set('roomKey', roomKey);
+    statusUrl.searchParams.set('userName', userName);
+    statusUrl.searchParams.set('sessionToken', sessionToken ?? '');
+
+    const response = await roomObject.fetch(
+      new Request(statusUrl.toString(), {
+        method: 'GET',
+      }) as unknown as CfRequest
+    );
+
+    if (!response.ok) {
+      return jsonError('Failed to get OAuth status', 500);
+    }
+
+    const data = await response.json<{
+      connected: boolean;
+      slackTeamId?: string;
+      slackTeamName?: string;
+      slackUserName?: string;
+      expiresAt?: number;
+    }>();
+
+    return jsonResponse(data);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : 'Failed to get OAuth status';
+    return jsonError(message, 500);
+  }
+}
+
+export async function revokeSlackOAuthController(
+  request: CfRequest,
+  env: Env
+): Promise<CfResponse> {
+  const body = await request.json<{
+    roomKey?: string;
+    userName?: string;
+    sessionToken?: string;
+  }>();
+
+  const roomKey = body?.roomKey;
+  const userName = body?.userName;
+  const sessionToken = body?.sessionToken;
+
+  if (!roomKey || !userName) {
+    return jsonError('Room key and user name are required');
+  }
+
+  try {
+    await validateSession(env, roomKey, userName, sessionToken);
+
+    const roomObject = getRoomStub(env, roomKey);
+    const response = await roomObject.fetch(
+      new Request('https://dummy/slack/oauth/revoke', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ roomKey, userName, sessionToken }),
+      }) as unknown as CfRequest
+    );
+
+    if (!response.ok) {
+      return jsonError('Failed to revoke OAuth credentials', 500);
+    }
+
+    return jsonResponse({ success: true });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to revoke OAuth credentials';
+    return jsonError(message, 500);
+  }
+}

--- a/api/index.ts
+++ b/api/index.ts
@@ -36,6 +36,17 @@ import {
   getLinearOAuthStatusController,
   revokeLinearOAuthController,
 } from "./controllers/linear-oauth-controller";
+import {
+  initiateSlackOAuthController,
+  handleSlackOAuthCallbackController,
+  getSlackOAuthStatusController,
+  revokeSlackOAuthController,
+} from "./controllers/slack-oauth-controller";
+import {
+  postSessionResultsController,
+  postSessionStartController,
+  postCustomMessageController,
+} from "./controllers/slack-controller";
 
 async function handleRequest(
   request: CfRequest,
@@ -163,6 +174,35 @@ async function handleApiRequest(
 
   if (path === "linear/oauth/revoke" && request.method === "DELETE") {
     return revokeLinearOAuthController(request, env);
+  }
+
+  // Slack routes
+  if (path === "slack/oauth/authorize" && request.method === "POST") {
+    return initiateSlackOAuthController(request, env);
+  }
+
+  if (path === "slack/oauth/callback" && request.method === "GET") {
+    return handleSlackOAuthCallbackController(url, env);
+  }
+
+  if (path === "slack/oauth/status" && request.method === "GET") {
+    return getSlackOAuthStatusController(url, env);
+  }
+
+  if (path === "slack/oauth/revoke" && request.method === "DELETE") {
+    return revokeSlackOAuthController(request, env);
+  }
+
+  if (path === "slack/post/results" && request.method === "POST") {
+    return postSessionResultsController(request, env);
+  }
+
+  if (path === "slack/post/start" && request.method === "POST") {
+    return postSessionStartController(request, env);
+  }
+
+  if (path === "slack/post/message" && request.method === "POST") {
+    return postCustomMessageController(request, env);
   }
 
   return new Response(JSON.stringify({ error: "Not found" }), {

--- a/api/services/slack-service.ts
+++ b/api/services/slack-service.ts
@@ -1,0 +1,400 @@
+import type { SlackOAuthCredentials, SlackMessage, RoomData } from '../types';
+
+function getOAuthHeaders(accessToken: string): Headers {
+  return new Headers({
+    Authorization: `Bearer ${accessToken}`,
+    'Content-Type': 'application/json',
+  });
+}
+
+async function refreshOAuthToken(
+  refreshToken: string,
+  clientId: string,
+  clientSecret: string
+): Promise<{
+  accessToken: string;
+  refreshToken: string;
+  expiresIn: number;
+}> {
+  const response = await fetch('https://slack.com/api/oauth.v2.access', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+    },
+    body: new URLSearchParams({
+      grant_type: 'refresh_token',
+      client_id: clientId,
+      client_secret: clientSecret,
+      refresh_token: refreshToken,
+    }).toString(),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.text();
+    console.error('Token refresh failed:', errorData);
+    throw new Error(
+      'Failed to refresh OAuth token. User needs to re-authenticate.'
+    );
+  }
+
+  const data = await response.json<{
+    ok: boolean;
+    access_token: string;
+    refresh_token: string;
+    expires_in: number;
+    error?: string;
+  }>();
+
+  if (!data.ok) {
+    throw new Error(`Slack token refresh failed: ${data.error || 'Unknown error'}`);
+  }
+
+  return {
+    accessToken: data.access_token,
+    refreshToken: data.refresh_token,
+    expiresIn: data.expires_in,
+  };
+}
+
+async function executeWithTokenRefresh<T>(
+  credentials: SlackOAuthCredentials,
+  operation: (accessToken: string) => Promise<T>,
+  onTokenRefresh: (
+    accessToken: string,
+    refreshToken: string,
+    expiresAt: number
+  ) => Promise<void>,
+  clientId: string,
+  clientSecret: string
+): Promise<T> {
+  const isExpiringSoon = credentials.expiresAt - Date.now() < 5 * 60 * 1000;
+
+  if (isExpiringSoon && credentials.refreshToken) {
+    try {
+      const refreshed = await refreshOAuthToken(
+        credentials.refreshToken,
+        clientId,
+        clientSecret
+      );
+
+      const newExpiresAt = Date.now() + refreshed.expiresIn * 1000;
+
+      await onTokenRefresh(
+        refreshed.accessToken,
+        refreshed.refreshToken,
+        newExpiresAt
+      );
+
+      return await operation(refreshed.accessToken);
+    } catch (error) {
+      console.error('Token refresh failed:', error);
+      // Try with existing token anyway
+    }
+  }
+
+  try {
+    return await operation(credentials.accessToken);
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      error.message.includes('401') &&
+      credentials.refreshToken
+    ) {
+      try {
+        const refreshed = await refreshOAuthToken(
+          credentials.refreshToken,
+          clientId,
+          clientSecret
+        );
+
+        const newExpiresAt = Date.now() + refreshed.expiresIn * 1000;
+
+        await onTokenRefresh(
+          refreshed.accessToken,
+          refreshed.refreshToken,
+          newExpiresAt
+        );
+
+        return await operation(refreshed.accessToken);
+      } catch (refreshError) {
+        console.error('Token refresh retry failed:', refreshError);
+        throw new Error(
+          'OAuth token expired. Please reconnect your Slack workspace.'
+        );
+      }
+    }
+    throw error;
+  }
+}
+
+async function executeSlackAPI<T>(
+  accessToken: string,
+  endpoint: string,
+  method: string = 'GET',
+  body?: Record<string, unknown>
+): Promise<T> {
+  const headers = getOAuthHeaders(accessToken);
+  const url = `https://slack.com/api/${endpoint}`;
+
+  const options: RequestInit = {
+    method,
+    headers,
+  };
+
+  if (body && method !== 'GET') {
+    options.body = JSON.stringify(body);
+  }
+
+  const response = await fetch(url, options);
+
+  if (!response.ok) {
+    if (response.status === 401) {
+      throw new Error('401: Unauthorized');
+    }
+    const bodyText = await response.text();
+    throw new Error(
+      `Slack API request failed: ${response.status} ${bodyText}`.trim()
+    );
+  }
+
+  const data = await response.json<T & { ok: boolean; error?: string }>();
+
+  if (!data.ok) {
+    throw new Error(`Slack API error: ${data.error || 'Unknown error'}`);
+  }
+
+  return data;
+}
+
+export async function postSlackMessage(
+  credentials: SlackOAuthCredentials,
+  message: SlackMessage,
+  onTokenRefresh: (
+    accessToken: string,
+    refreshToken: string,
+    expiresAt: number
+  ) => Promise<void>,
+  clientId: string,
+  clientSecret: string
+): Promise<{ ts: string; channel: string }> {
+  return executeWithTokenRefresh(
+    credentials,
+    async (accessToken) => {
+      const data = await executeSlackAPI<{
+        ok: boolean;
+        ts: string;
+        channel: string;
+      }>(accessToken, 'chat.postMessage', 'POST', message);
+
+      return {
+        ts: data.ts,
+        channel: data.channel,
+      };
+    },
+    onTokenRefresh,
+    clientId,
+    clientSecret
+  );
+}
+
+export async function getSlackTeamInfo(
+  accessToken: string
+): Promise<{
+  id: string;
+  name: string;
+}> {
+  const data = await executeSlackAPI<{
+    ok: boolean;
+    team: {
+      id: string;
+      name: string;
+    };
+  }>(accessToken, 'team.info');
+
+  return data.team;
+}
+
+export async function getSlackUserInfo(
+  accessToken: string
+): Promise<{
+  id: string;
+  name: string;
+  email?: string;
+}> {
+  const data = await executeSlackAPI<{
+    ok: boolean;
+    user: {
+      id: string;
+      name: string;
+      profile?: {
+        email?: string;
+      };
+    };
+  }>(accessToken, 'auth.test');
+
+  return {
+    id: data.user.id,
+    name: data.user.name,
+    email: data.user.profile?.email,
+  };
+}
+
+export function formatVotingResultsForSlack(roomData: RoomData): SlackMessage {
+  const channel = roomData.settings.externalService === 'slack' ? '' : '';
+
+  // Calculate voting statistics
+  const votes = Object.entries(roomData.votes)
+    .filter(([_, vote]) => vote !== null)
+    .map(([user, vote]) => ({ user, vote }));
+
+  const voteValues = votes
+    .map(v => v.vote)
+    .filter(v => typeof v === 'number' || !isNaN(Number(v)))
+    .map(v => Number(v));
+
+  const average = voteValues.length > 0
+    ? (voteValues.reduce((a, b) => a + b, 0) / voteValues.length).toFixed(1)
+    : 'N/A';
+
+  const median = voteValues.length > 0
+    ? (() => {
+        const sorted = [...voteValues].sort((a, b) => a - b);
+        const mid = Math.floor(sorted.length / 2);
+        return sorted.length % 2 === 0
+          ? ((sorted[mid - 1] + sorted[mid]) / 2).toFixed(1)
+          : sorted[mid].toString();
+      })()
+    : 'N/A';
+
+  // Build vote distribution
+  const voteDistribution = votes.reduce((acc, { vote }) => {
+    const key = String(vote);
+    acc[key] = (acc[key] || 0) + 1;
+    return acc;
+  }, {} as Record<string, number>);
+
+  const distributionText = Object.entries(voteDistribution)
+    .sort((a, b) => Number(b[1]) - Number(a[1]))
+    .map(([vote, count]) => `*${vote}*: ${count} vote${count > 1 ? 's' : ''}`)
+    .join(' | ');
+
+  const ticketInfo = roomData.currentTicket
+    ? `*Ticket:* ${roomData.currentTicket.title || roomData.currentTicket.ticketId}`
+    : '*Planning Poker Session*';
+
+  return {
+    channel,
+    blocks: [
+      {
+        type: 'header',
+        text: {
+          type: 'plain_text',
+          text: '🎯 Voting Results',
+          emoji: true,
+        },
+      },
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: ticketInfo,
+        },
+      },
+      {
+        type: 'section',
+        fields: [
+          {
+            type: 'mrkdwn',
+            text: `*Average:*\n${average}`,
+          },
+          {
+            type: 'mrkdwn',
+            text: `*Median:*\n${median}`,
+          },
+          {
+            type: 'mrkdwn',
+            text: `*Total Votes:*\n${votes.length}`,
+          },
+          {
+            type: 'mrkdwn',
+            text: `*Participants:*\n${roomData.users.length}`,
+          },
+        ],
+      },
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `*Vote Distribution:*\n${distributionText}`,
+        },
+      },
+      {
+        type: 'divider',
+      },
+      {
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: `Room: *${roomData.key}* | Posted by SprintJam`,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+export function formatSessionStartForSlack(roomData: RoomData): SlackMessage {
+  const channel = roomData.settings.externalService === 'slack' ? '' : '';
+
+  const ticketInfo = roomData.currentTicket
+    ? `*Ticket:* ${roomData.currentTicket.title || roomData.currentTicket.ticketId}`
+    : '*New Planning Poker Session*';
+
+  return {
+    channel,
+    blocks: [
+      {
+        type: 'header',
+        text: {
+          type: 'plain_text',
+          text: '🚀 Planning Session Started',
+          emoji: true,
+        },
+      },
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: ticketInfo,
+        },
+      },
+      {
+        type: 'section',
+        fields: [
+          {
+            type: 'mrkdwn',
+            text: `*Room:*\n${roomData.key}`,
+          },
+          {
+            type: 'mrkdwn',
+            text: `*Moderator:*\n${roomData.moderator}`,
+          },
+          {
+            type: 'mrkdwn',
+            text: `*Participants:*\n${roomData.users.length}`,
+          },
+        ],
+      },
+      {
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: 'Posted by SprintJam',
+          },
+        ],
+      },
+    ],
+  };
+}

--- a/api/types.ts
+++ b/api/types.ts
@@ -13,6 +13,9 @@ export interface Env {
   LINEAR_OAUTH_CLIENT_ID?: string;
   LINEAR_OAUTH_CLIENT_SECRET?: string;
   LINEAR_OAUTH_REDIRECT_URI?: string;
+  SLACK_OAUTH_CLIENT_ID?: string;
+  SLACK_OAUTH_CLIENT_SECRET?: string;
+  SLACK_OAUTH_REDIRECT_URI?: string;
   POLYCHAT_API_TOKEN?: string;
 }
 
@@ -122,7 +125,7 @@ export interface RoomSettings {
   enableJudge: boolean;
   judgeAlgorithm: JudgeAlgorithm;
   hideParticipantNames?: boolean;
-  externalService?: 'jira' | 'linear' | 'none';
+  externalService?: 'jira' | 'linear' | 'slack' | 'none';
   enableStructuredVoting?: boolean;
   votingCriteria?: VotingCriterion[];
   autoUpdateJiraStoryPoints?: boolean;
@@ -242,7 +245,7 @@ export interface TicketQueueItem {
   createdAt: number;
   completedAt?: number;
   ordinal: number;
-  externalService: 'jira' | 'linear' | 'none';
+  externalService: 'jira' | 'linear' | 'slack' | 'none';
   externalServiceId?: string;
   externalServiceMetadata?: Record<string, unknown>;
   votes?: TicketVote[];
@@ -278,4 +281,47 @@ export interface SessionInfo {
   webSocket: CfWebSocket;
   roomKey: string;
   userName: string;
+}
+
+export interface SlackOAuthCredentials {
+  id: number;
+  roomKey: string;
+  accessToken: string;
+  refreshToken: string | null;
+  tokenType: string;
+  expiresAt: number;
+  scope: string | null;
+  slackTeamId: string | null;
+  slackTeamName: string | null;
+  slackChannelId: string | null;
+  slackChannelName: string | null;
+  slackUserId: string | null;
+  slackUserName: string | null;
+  authorizedBy: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface SlackMessage {
+  channel: string;
+  text?: string;
+  blocks?: SlackBlock[];
+  thread_ts?: string;
+  attachments?: SlackAttachment[];
+}
+
+export interface SlackBlock {
+  type: string;
+  [key: string]: unknown;
+}
+
+export interface SlackAttachment {
+  color?: string;
+  title?: string;
+  text?: string;
+  fields?: Array<{
+    title: string;
+    value: string;
+    short?: boolean;
+  }>;
 }

--- a/src/hooks/useSlackOAuth.ts
+++ b/src/hooks/useSlackOAuth.ts
@@ -1,0 +1,131 @@
+import { useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { useRoom } from '@/context/RoomContext';
+import { useSession } from '@/context/SessionContext';
+import {
+  authorizeSlackOAuth,
+  getSlackOAuthStatus,
+  revokeSlackOAuth,
+  type SlackOAuthStatus,
+} from "@/lib/slack-service";
+
+export function useSlackOAuth(enabled = true) {
+  const { activeRoomKey, authToken } = useRoom();
+  const { name } = useSession();
+  const queryClient = useQueryClient();
+  const [clientError, setClientError] = useState<string | null>(null);
+
+  const hasRequiredContext =
+    enabled && Boolean(activeRoomKey && name && authToken);
+
+  const statusQuery = useQuery<SlackOAuthStatus>({
+    queryKey: ["slack-oauth-status", activeRoomKey, name, authToken],
+    enabled: hasRequiredContext,
+    queryFn: () =>
+      getSlackOAuthStatus(
+        activeRoomKey ?? "",
+        name ?? "",
+        authToken ?? "",
+      ),
+    staleTime: 1000 * 30,
+  });
+
+  const connect = async () => {
+    if (!hasRequiredContext) {
+      setClientError("Missing room key, user name, or session token");
+      return;
+    }
+
+    setClientError(null);
+    return connectMutation.mutateAsync();
+  };
+
+  const disconnect = async () => {
+    if (!hasRequiredContext) {
+      setClientError("Missing room key, user name, or session token");
+      return;
+    }
+
+    setClientError(null);
+    return disconnectMutation.mutateAsync();
+  };
+
+  const connectMutation = useMutation({
+    mutationKey: ["slack-oauth-connect", activeRoomKey, name],
+    mutationFn: async () => {
+      const { authorizationUrl } = await authorizeSlackOAuth(
+        activeRoomKey ?? "",
+        name ?? "",
+        authToken ?? "",
+      );
+
+      const width = 600;
+      const height = 700;
+      const left = window.screen.width / 2 - width / 2;
+      const top = window.screen.height / 2 - height / 2;
+
+      const authWindow = window.open(
+        authorizationUrl,
+        "Slack OAuth",
+        `width=${width},height=${height},left=${left},top=${top}`,
+      );
+
+      const pollTimer = setInterval(() => {
+        if (authWindow?.closed) {
+          clearInterval(pollTimer);
+          setTimeout(() => {
+            void statusQuery.refetch();
+          }, 1000);
+        }
+      }, 500);
+    },
+  });
+
+  const disconnectMutation = useMutation({
+    mutationKey: ["slack-oauth-disconnect", activeRoomKey, name],
+    mutationFn: async () => {
+      await revokeSlackOAuth(activeRoomKey ?? "", name ?? "", authToken ?? "");
+
+      queryClient.setQueryData<SlackOAuthStatus>(
+        ["slack-oauth-status", activeRoomKey, name, authToken],
+        { connected: false },
+      );
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["slack-oauth-status", activeRoomKey, name, authToken],
+      });
+    },
+  });
+
+  const status =
+    statusQuery.data && hasRequiredContext
+      ? statusQuery.data
+      : { connected: false };
+
+  const loading =
+    (hasRequiredContext && statusQuery.isLoading) ||
+    connectMutation.isPending ||
+    disconnectMutation.isPending;
+
+  const error =
+    clientError ||
+    (statusQuery.error instanceof Error ? statusQuery.error.message : null) ||
+    (connectMutation.error instanceof Error
+      ? connectMutation.error.message
+      : null) ||
+    (disconnectMutation.error instanceof Error
+      ? disconnectMutation.error.message
+      : null) ||
+    null;
+
+  return {
+    status,
+    loading,
+    error,
+    connect,
+    disconnect,
+    refresh: () => statusQuery.refetch(),
+  };
+}

--- a/src/lib/slack-service.ts
+++ b/src/lib/slack-service.ts
@@ -1,0 +1,190 @@
+import type { RoomData } from "@/types";
+import { API_BASE_URL } from "@/constants";
+import { safeLocalStorage } from "@/utils/storage";
+import { AUTH_TOKEN_STORAGE_KEY } from "@/constants";
+
+function resolveSessionToken(provided?: string | null): string {
+  if (provided) return provided;
+  const stored = safeLocalStorage.get(AUTH_TOKEN_STORAGE_KEY);
+  if (!stored) {
+    throw new Error("Missing session token. Please rejoin the room.");
+  }
+  return stored;
+}
+
+export interface SlackOAuthStatus {
+  connected: boolean;
+  slackTeamId?: string;
+  slackTeamName?: string;
+  slackUserName?: string;
+  slackChannelId?: string;
+  slackChannelName?: string;
+  expiresAt?: number;
+}
+
+export async function getSlackOAuthStatus(
+  roomKey: string,
+  userName: string,
+  sessionToken?: string | null,
+): Promise<SlackOAuthStatus> {
+  const token = resolveSessionToken(sessionToken);
+  const response = await fetch(
+    `${API_BASE_URL}/slack/oauth/status?roomKey=${encodeURIComponent(
+      roomKey,
+    )}&userName=${encodeURIComponent(userName)}&sessionToken=${encodeURIComponent(
+      token,
+    )}`,
+  );
+
+  if (!response.ok) {
+    throw new Error("Failed to fetch OAuth status");
+  }
+
+  return (await response.json()) as SlackOAuthStatus;
+}
+
+export async function authorizeSlackOAuth(
+  roomKey: string,
+  userName: string,
+  sessionToken?: string | null,
+): Promise<{ authorizationUrl: string }> {
+  const token = resolveSessionToken(sessionToken);
+  const response = await fetch(`${API_BASE_URL}/slack/oauth/authorize`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      roomKey,
+      userName,
+      sessionToken: token,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(errorData.error || "Failed to initiate OAuth");
+  }
+
+  return (await response.json()) as { authorizationUrl: string };
+}
+
+export async function revokeSlackOAuth(
+  roomKey: string,
+  userName: string,
+  sessionToken?: string | null,
+): Promise<void> {
+  const token = resolveSessionToken(sessionToken);
+  const response = await fetch(`${API_BASE_URL}/slack/oauth/revoke`, {
+    method: "DELETE",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      roomKey,
+      userName,
+      sessionToken: token,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(errorData.error || "Failed to disconnect Slack");
+  }
+}
+
+export async function postSessionResults(
+  roomKey: string,
+  userName: string,
+  roomData: RoomData,
+  sessionToken?: string | null,
+): Promise<{ success: boolean; messageTs: string; channel: string }> {
+  const token = resolveSessionToken(sessionToken);
+  const response = await fetch(`${API_BASE_URL}/slack/post/results`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      roomKey,
+      userName,
+      sessionToken: token,
+      roomData,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(errorData.error || "Failed to post results to Slack");
+  }
+
+  return (await response.json()) as {
+    success: boolean;
+    messageTs: string;
+    channel: string;
+  };
+}
+
+export async function postSessionStart(
+  roomKey: string,
+  userName: string,
+  roomData: RoomData,
+  sessionToken?: string | null,
+): Promise<{ success: boolean; messageTs: string; channel: string }> {
+  const token = resolveSessionToken(sessionToken);
+  const response = await fetch(`${API_BASE_URL}/slack/post/start`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      roomKey,
+      userName,
+      sessionToken: token,
+      roomData,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(errorData.error || "Failed to post session start to Slack");
+  }
+
+  return (await response.json()) as {
+    success: boolean;
+    messageTs: string;
+    channel: string;
+  };
+}
+
+export async function postCustomMessage(
+  roomKey: string,
+  userName: string,
+  text: string,
+  sessionToken?: string | null,
+): Promise<{ success: boolean; messageTs: string; channel: string }> {
+  const token = resolveSessionToken(sessionToken);
+  const response = await fetch(`${API_BASE_URL}/slack/post/message`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      roomKey,
+      userName,
+      sessionToken: token,
+      text,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json();
+    throw new Error(errorData.error || "Failed to post message to Slack");
+  }
+
+  return (await response.json()) as {
+    success: boolean;
+    messageTs: string;
+    channel: string;
+  };
+}


### PR DESCRIPTION
- Add Slack OAuth 2.0 authentication flow
- Support posting session results and updates to Slack channels
- Add API endpoints for Slack OAuth (authorize, callback, status, revoke)
- Add API endpoints for posting messages (results, session start, custom)
- Update database schema to support Slack credentials
- Create frontend hooks and services for Slack integration
- Update documentation with Slack configuration instructions

This enables teams to run planning poker sessions over Slack by:
1. Connecting their Slack workspace via OAuth
2. Automatically posting voting results to configured channels
3. Notifying teams when sessions start
4. Sending custom messages to Slack

Slack integration follows the same pattern as existing Jira and Linear integrations, with full token refresh support and session validation.