### PR TITLE
feat(wip): adding stats tracking

### DIFF
--- a/apps/app/api/index.ts
+++ b/apps/app/api/index.ts
@@ -2,63 +2,67 @@ import type {
   ExportedHandler,
   Request as CfRequest,
   Response as CfResponse,
-} from '@cloudflare/workers-types';
-import type { DispatchWorkerEnv } from '@sprintjam/types';
+} from "@cloudflare/workers-types";
+import type { DispatchWorkerEnv } from "@sprintjam/types";
 
 function handleRobotsTxt(env: DispatchWorkerEnv): CfResponse {
-  const isStaging = env.ENVIRONMENT === 'staging';
+  const isStaging = env.ENVIRONMENT === "staging";
   const robotsBody = isStaging
-    ? 'User-agent: *\nDisallow: /'
-    : 'User-agent: *\nAllow: /';
+    ? "User-agent: *\nDisallow: /"
+    : "User-agent: *\nAllow: /";
 
   return new Response(robotsBody, {
     status: 200,
     headers: {
-      'Content-Type': 'text/plain; charset=utf-8',
-      ...(isStaging ? { 'X-Robots-Tag': 'noindex, nofollow' } : {}),
+      "Content-Type": "text/plain; charset=utf-8",
+      ...(isStaging ? { "X-Robots-Tag": "noindex, nofollow" } : {}),
     },
   }) as unknown as CfResponse;
 }
 
 async function handleRequest(
   request: CfRequest,
-  env: DispatchWorkerEnv
+  env: DispatchWorkerEnv,
 ): Promise<CfResponse> {
   try {
     const url = new URL(request.url);
 
-    if (url.pathname === '/robots.txt') {
+    if (url.pathname === "/robots.txt") {
       return handleRobotsTxt(env);
     }
 
-    if (url.pathname.startsWith('/api/')) {
+    if (url.pathname.startsWith("/api/")) {
       const path = url.pathname.substring(5); // Remove '/api/'
 
       if (
-        path.startsWith('auth/') ||
-        path === 'teams' ||
-        path.startsWith('teams/') ||
-        path.startsWith('workspace/')
+        path.startsWith("auth/") ||
+        path === "teams" ||
+        path.startsWith("teams/") ||
+        path.startsWith("workspace/")
       ) {
         return await env.AUTH_WORKER.fetch(request);
+      }
+
+      if (path.startsWith("stats/")) {
+        return await env.STATS_WORKER.fetch(request);
       }
 
       return await env.ROOM_WORKER.fetch(request);
     }
 
-    if (url.pathname === '/ws') {
+    if (url.pathname === "/ws") {
       return await env.ROOM_WORKER.fetch(request);
     }
 
     return env.ASSETS.fetch(request);
   } catch (error) {
-    console.error('[main] Internal Server Error', error);
+    console.error("[main] Internal Server Error", error);
     return new Response(
-      JSON.stringify({ error: '[main] handleRequest errored' }),
+      JSON.stringify({ error: "[main] handleRequest errored" }),
       {
         status: 500,
-        headers: { 'Content-Type': 'application/json' },
-      }
+        headers: { "Content-Type": "application/json" },
+      },
     ) as unknown as CfResponse;
   }
 }

--- a/apps/app/src/components/modals/CompleteSessionModal.tsx
+++ b/apps/app/src/components/modals/CompleteSessionModal.tsx
@@ -1,9 +1,13 @@
-import { FC } from 'react';
+import { FC } from "react";
+import { BarChart3, Users, Target, TrendingUp } from "lucide-react";
 
-import type { TicketQueueItem } from '@/types';
-import { Modal } from '@/components/ui/Modal';
-import { Button } from '@/components/ui/Button';
-import { TicketQueueModalContent } from '@/components/modals/TicketQueueModal/Content';
+import type { TicketQueueItem } from "@/types";
+import { Modal } from "@/components/ui/Modal";
+import { Button } from "@/components/ui/Button";
+import { SurfaceCard } from "@/components/ui/SurfaceCard";
+import { Spinner } from "@/components/ui/Spinner";
+import { TicketQueueModalContent } from "@/components/modals/TicketQueueModal/Content";
+import { useRoomVotingStats } from "@/hooks/useVotingStats";
 
 interface CompleteSessionModalProps {
   isOpen: boolean;
@@ -11,7 +15,7 @@ interface CompleteSessionModalProps {
   isQueueEnabled: boolean;
   currentTicket?: TicketQueueItem;
   queue: TicketQueueItem[];
-  externalService: 'none' | 'jira' | 'linear' | 'github';
+  externalService: "none" | "jira" | "linear" | "github";
   roomKey: string;
   userName: string;
   onAddTicket: (ticket: Partial<TicketQueueItem>) => void;
@@ -42,9 +46,91 @@ export const CompleteSessionModal: FC<CompleteSessionModalProps> = ({
   showSaveToWorkspace = false,
   onError,
 }) => {
+  const { stats, isLoading: isLoadingStats } = useRoomVotingStats(
+    isOpen ? roomKey : null,
+  );
+
+  const completedTickets = queue.filter((t) => t.completedAt).length;
+
   return (
     <Modal isOpen={isOpen} onClose={onClose} title="Complete session" size="lg">
       <div className="space-y-6">
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+          <SurfaceCard variant="subtle" padding="sm">
+            <div className="flex items-center gap-3">
+              <div className="rounded-lg bg-brand-100 p-2 dark:bg-brand-900/40">
+                <Target className="h-4 w-4 text-brand-600 dark:text-brand-400" />
+              </div>
+              <div>
+                <p className="text-xs text-slate-500 dark:text-slate-400">
+                  Rounds
+                </p>
+                <p className="text-lg font-semibold text-slate-900 dark:text-white">
+                  {isLoadingStats ? (
+                    <Spinner size="sm" />
+                  ) : (
+                    (stats?.totalRounds ?? 0)
+                  )}
+                </p>
+              </div>
+            </div>
+          </SurfaceCard>
+
+          <SurfaceCard variant="subtle" padding="sm">
+            <div className="flex items-center gap-3">
+              <div className="rounded-lg bg-indigo-100 p-2 dark:bg-indigo-900/40">
+                <BarChart3 className="h-4 w-4 text-indigo-600 dark:text-indigo-400" />
+              </div>
+              <div>
+                <p className="text-xs text-slate-500 dark:text-slate-400">
+                  Votes
+                </p>
+                <p className="text-lg font-semibold text-slate-900 dark:text-white">
+                  {isLoadingStats ? (
+                    <Spinner size="sm" />
+                  ) : (
+                    (stats?.totalVotes ?? 0)
+                  )}
+                </p>
+              </div>
+            </div>
+          </SurfaceCard>
+
+          {isQueueEnabled && (
+            <SurfaceCard variant="subtle" padding="sm">
+              <div className="flex items-center gap-3">
+                <div className="rounded-lg bg-emerald-100 p-2 dark:bg-emerald-900/40">
+                  <TrendingUp className="h-4 w-4 text-emerald-600 dark:text-emerald-400" />
+                </div>
+                <div>
+                  <p className="text-xs text-slate-500 dark:text-slate-400">
+                    Completed
+                  </p>
+                  <p className="text-lg font-semibold text-slate-900 dark:text-white">
+                    {completedTickets} / {queue.length}
+                  </p>
+                </div>
+              </div>
+            </SurfaceCard>
+          )}
+
+          <SurfaceCard variant="subtle" padding="sm">
+            <div className="flex items-center gap-3">
+              <div className="rounded-lg bg-amber-100 p-2 dark:bg-amber-900/40">
+                <Users className="h-4 w-4 text-amber-600 dark:text-amber-400" />
+              </div>
+              <div>
+                <p className="text-xs text-slate-500 dark:text-slate-400">
+                  Room
+                </p>
+                <p className="truncate text-lg font-semibold text-slate-900 dark:text-white">
+                  {roomKey}
+                </p>
+              </div>
+            </div>
+          </SurfaceCard>
+        </div>
+
         {isQueueEnabled ? (
           <TicketQueueModalContent
             currentTicket={currentTicket}
@@ -61,18 +147,15 @@ export const CompleteSessionModal: FC<CompleteSessionModalProps> = ({
             onError={onError}
           />
         ) : (
-          <div className="rounded-xl border border-slate-200 bg-white p-4 text-sm text-slate-600 shadow-sm dark:border-slate-800 dark:bg-slate-900/60 dark:text-slate-300">
-            Ticket queue is disabled for this room. Saving a session without a
-            queue is coming soon—use the save button to link this room to your
-            workspace for now.
-          </div>
+          <SurfaceCard variant="subtle" padding="sm">
+            <p className="text-sm text-slate-600 dark:text-slate-300">
+              This session was run without a ticket queue. Your voting stats
+              have been recorded and will appear in your workspace dashboard.
+            </p>
+          </SurfaceCard>
         )}
 
         <div className="flex flex-wrap items-center justify-end gap-2 border-t border-slate-200 pt-4 dark:border-slate-800">
-          <small>
-            Note: At the moment, completing the session only closes this modal,
-            in the future, stats for the room will be displayed.
-          </small>
           {showSaveToWorkspace && onSaveToWorkspace && (
             <Button
               type="button"

--- a/apps/app/src/hooks/useVotingStats.ts
+++ b/apps/app/src/hooks/useVotingStats.ts
@@ -1,0 +1,150 @@
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  getBatchRoomStats,
+  getRoomStats,
+  getTeamStats,
+  getUserRoomStats,
+  type RoomStats,
+  type TeamStats,
+  type UserRoomStats,
+} from "@/lib/stats-service";
+
+export function useTeamVotingStats(teamId: number | null) {
+  const [stats, setStats] = useState<TeamStats | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refetch = useCallback(async () => {
+    if (!teamId) {
+      setStats(null);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const data = await getTeamStats(teamId);
+      setStats(data);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to load team stats",
+      );
+      setStats(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [teamId]);
+
+  useEffect(() => {
+    void refetch();
+  }, [refetch]);
+
+  return { stats, isLoading, error, refetch };
+}
+
+export function useRoomVotingStats(roomKey: string | null) {
+  const [stats, setStats] = useState<RoomStats | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refetch = useCallback(async () => {
+    if (!roomKey) {
+      setStats(null);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const data = await getRoomStats(roomKey);
+      setStats(data);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to load room stats",
+      );
+      setStats(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [roomKey]);
+
+  useEffect(() => {
+    void refetch();
+  }, [refetch]);
+
+  return { stats, isLoading, error, refetch };
+}
+
+export function useUserRoomVotingStats(
+  roomKey: string | null,
+  userName: string | null,
+) {
+  const [stats, setStats] = useState<UserRoomStats | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refetch = useCallback(async () => {
+    if (!roomKey || !userName) {
+      setStats(null);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const data = await getUserRoomStats(roomKey, userName);
+      setStats(data);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to load user stats",
+      );
+      setStats(null);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [roomKey, userName]);
+
+  useEffect(() => {
+    void refetch();
+  }, [refetch]);
+
+  return { stats, isLoading, error, refetch };
+}
+
+export function useBatchRoomStats(roomKeys: string[]) {
+  const [stats, setStats] = useState<Record<string, RoomStats>>({});
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refetch = useCallback(async () => {
+    if (roomKeys.length === 0) {
+      setStats({});
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const data = await getBatchRoomStats(roomKeys);
+      setStats(data);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to load room stats",
+      );
+      setStats({});
+    } finally {
+      setIsLoading(false);
+    }
+  }, [roomKeys]);
+
+  useEffect(() => {
+    void refetch();
+  }, [refetch]);
+
+  return { stats, isLoading, error, refetch };
+}

--- a/apps/app/src/lib/stats-service.ts
+++ b/apps/app/src/lib/stats-service.ts
@@ -1,0 +1,80 @@
+import { API_BASE_URL } from "@/constants";
+
+import { workspaceRequest } from "./workspace-service";
+
+export interface RoomStats {
+  roomKey: string;
+  totalRounds: number;
+  totalVotes: number;
+  lastUpdatedAt: number;
+}
+
+export interface UserRoomStats {
+  userName: string;
+  totalVotes: number;
+  participationRate: number;
+  consensusAlignment: number;
+  judgeAlignment: number;
+  voteDistribution: Record<string, number>;
+}
+
+export interface TeamStats {
+  totalMembers: number;
+  totalRounds: number;
+  avgParticipation: number;
+  consensusRate: number;
+  memberStats: UserRoomStats[];
+}
+
+const STATS_API_BASE = `${API_BASE_URL}/stats`;
+
+export async function getRoomStats(roomKey: string): Promise<RoomStats | null> {
+  try {
+    const data = await workspaceRequest<{ stats: RoomStats }>(
+      `${STATS_API_BASE}/room/${encodeURIComponent(roomKey)}`,
+    );
+    return data.stats;
+  } catch {
+    return null;
+  }
+}
+
+export async function getUserRoomStats(
+  roomKey: string,
+  userName: string,
+): Promise<UserRoomStats | null> {
+  try {
+    const data = await workspaceRequest<{ stats: UserRoomStats }>(
+      `${STATS_API_BASE}/room/${encodeURIComponent(roomKey)}/user/${encodeURIComponent(userName)}`,
+    );
+    return data.stats;
+  } catch {
+    return null;
+  }
+}
+
+export async function getBatchRoomStats(
+  roomKeys: string[],
+): Promise<Record<string, RoomStats>> {
+  if (roomKeys.length === 0) return {};
+
+  try {
+    const data = await workspaceRequest<{ stats: Record<string, RoomStats> }>(
+      `${STATS_API_BASE}/rooms?keys=${roomKeys.map(encodeURIComponent).join(",")}`,
+    );
+    return data.stats;
+  } catch {
+    return {};
+  }
+}
+
+export async function getTeamStats(teamId: number): Promise<TeamStats | null> {
+  try {
+    const data = await workspaceRequest<{ stats: TeamStats }>(
+      `${STATS_API_BASE}/team/${teamId}`,
+    );
+    return data.stats;
+  } catch {
+    return null;
+  }
+}

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -7,28 +7,28 @@ import path from "path";
 export default defineConfig(({ command }) => ({
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src'),
+      "@": path.resolve(__dirname, "./src"),
     },
   },
   build: {
     rollupOptions: {
       output: {
         manualChunks: {
-          'react-vendor': ['react', 'react-dom'],
-          'strudel-vendor': ['@strudel/web'],
-          'tanstack-vendor': [
-            '@tanstack/react-query',
-            '@tanstack/db',
-            '@tanstack/query-core',
-            '@tanstack/query-db-collection',
+          "react-vendor": ["react", "react-dom"],
+          "strudel-vendor": ["@strudel/web"],
+          "tanstack-vendor": [
+            "@tanstack/react-query",
+            "@tanstack/db",
+            "@tanstack/query-core",
+            "@tanstack/query-db-collection",
           ],
-          'framer-vendor': ['framer-motion'],
-          'icons-vendor': ['lucide-react'],
-          'ui-vendor': ['qrcode.react', 'canvas-confetti'],
+          "framer-vendor": ["framer-motion"],
+          "icons-vendor": ["lucide-react"],
+          "ui-vendor": ["qrcode.react", "canvas-confetti"],
         },
       },
     },
-    sourcemap: command === 'build' ? false : true,
+    sourcemap: command === "build" ? false : true,
   },
   plugins: [
     react(),
@@ -36,14 +36,17 @@ export default defineConfig(({ command }) => ({
     cloudflare({
       auxiliaryWorkers: [
         {
-          configPath: '../room-worker/wrangler.jsonc',
+          configPath: "../room-worker/wrangler.jsonc",
         },
         {
-          configPath: '../auth-worker/wrangler.jsonc',
+          configPath: "../auth-worker/wrangler.jsonc",
+        },
+        {
+          configPath: "../stats-worker/wrangler.jsonc",
         },
       ],
       persistState: {
-        path: '../../.data',
+        path: "../../.data",
       },
     }),
   ],

--- a/apps/app/wrangler.jsonc
+++ b/apps/app/wrangler.jsonc
@@ -26,6 +26,10 @@
       "binding": "AUTH_WORKER",
       "service": "sprintjam-auth-worker",
     },
+    {
+      "binding": "STATS_WORKER",
+      "service": "sprintjam-stats-worker",
+    },
   ],
   "assets": {
     "binding": "ASSETS",
@@ -63,6 +67,10 @@
           "binding": "AUTH_WORKER",
           "service": "sprintjam-auth-worker-development",
         },
+        {
+          "binding": "STATS_WORKER",
+          "service": "sprintjam-stats-worker-development",
+        },
       ],
       "migrations": [],
     },
@@ -85,6 +93,10 @@
         {
           "binding": "AUTH_WORKER",
           "service": "sprintjam-auth-worker-staging",
+        },
+        {
+          "binding": "STATS_WORKER",
+          "service": "sprintjam-stats-worker-staging",
         },
       ],
     },

--- a/apps/auth-worker/drizzle/0002_wandering_johnny_storm.sql
+++ b/apps/auth-worker/drizzle/0002_wandering_johnny_storm.sql
@@ -1,0 +1,37 @@
+CREATE TABLE `round_votes` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`room_key` text NOT NULL,
+	`round_id` text NOT NULL,
+	`ticket_id` text,
+	`judge_score` text,
+	`judge_metadata` text,
+	`round_ended_at` integer NOT NULL,
+	`created_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `round_votes_round_id_unique` ON `round_votes` (`round_id`);--> statement-breakpoint
+CREATE INDEX `idx_round_votes_room` ON `round_votes` (`room_key`);--> statement-breakpoint
+CREATE INDEX `idx_round_votes_ended` ON `round_votes` (`round_ended_at`);--> statement-breakpoint
+CREATE TABLE `vote_records` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`round_id` text NOT NULL,
+	`user_name` text NOT NULL,
+	`vote` text NOT NULL,
+	`structured_vote_payload` text,
+	`voted_at` integer NOT NULL,
+	FOREIGN KEY (`round_id`) REFERENCES `round_votes`(`round_id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_vote_records_round` ON `vote_records` (`round_id`);--> statement-breakpoint
+CREATE INDEX `idx_vote_records_user` ON `vote_records` (`user_name`);--> statement-breakpoint
+CREATE UNIQUE INDEX `vote_records_round_user` ON `vote_records` (`round_id`,`user_name`);--> statement-breakpoint
+CREATE TABLE `room_stats` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`room_key` text NOT NULL,
+	`total_rounds` integer DEFAULT 0 NOT NULL,
+	`total_votes` integer DEFAULT 0 NOT NULL,
+	`last_updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `room_stats_room_key_unique` ON `room_stats` (`room_key`);--> statement-breakpoint
+CREATE INDEX `idx_room_stats_key` ON `room_stats` (`room_key`);

--- a/apps/auth-worker/drizzle/meta/0002_snapshot.json
+++ b/apps/auth-worker/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,758 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "73d551d8-4746-4b35-9a62-cd06683060f2",
+  "prevId": "25e5f164-5279-4991-a772-d0450a3fe59a",
+  "tables": {
+    "allowed_domains": {
+      "name": "allowed_domains",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "allowed_domains_domain_unique": {
+          "name": "allowed_domains_domain_unique",
+          "columns": [
+            "domain"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "organisations": {
+      "name": "organisations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "domain": {
+          "name": "domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "organisations_domain_unique": {
+          "name": "organisations_domain_unique",
+          "columns": [
+            "domain"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_domain": {
+          "name": "email_domain",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "users_organisation_id_organisations_id_fk": {
+          "name": "users_organisation_id_organisations_id_fk",
+          "tableFrom": "users",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "teams": {
+      "name": "teams",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "organisation_id": {
+          "name": "organisation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "teams_organisation_id_organisations_id_fk": {
+          "name": "teams_organisation_id_organisations_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "organisations",
+          "columnsFrom": [
+            "organisation_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "teams_owner_id_users_id_fk": {
+          "name": "teams_owner_id_users_id_fk",
+          "tableFrom": "teams",
+          "tableTo": "users",
+          "columnsFrom": [
+            "owner_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "magic_links": {
+      "name": "magic_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "magic_links_token_hash_unique": {
+          "name": "magic_links_token_hash_unique",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "workspace_sessions": {
+      "name": "workspace_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "workspace_sessions_token_hash_unique": {
+          "name": "workspace_sessions_token_hash_unique",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "workspace_sessions_user_id_users_id_fk": {
+          "name": "workspace_sessions_user_id_users_id_fk",
+          "tableFrom": "workspace_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "team_sessions": {
+      "name": "team_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "team_id": {
+          "name": "team_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "room_key": {
+          "name": "room_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by_id": {
+          "name": "created_by_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "team_sessions_team_id_teams_id_fk": {
+          "name": "team_sessions_team_id_teams_id_fk",
+          "tableFrom": "team_sessions",
+          "tableTo": "teams",
+          "columnsFrom": [
+            "team_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "team_sessions_created_by_id_users_id_fk": {
+          "name": "team_sessions_created_by_id_users_id_fk",
+          "tableFrom": "team_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "round_votes": {
+      "name": "round_votes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "room_key": {
+          "name": "room_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "round_id": {
+          "name": "round_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ticket_id": {
+          "name": "ticket_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "judge_score": {
+          "name": "judge_score",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "judge_metadata": {
+          "name": "judge_metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "round_ended_at": {
+          "name": "round_ended_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "round_votes_round_id_unique": {
+          "name": "round_votes_round_id_unique",
+          "columns": [
+            "round_id"
+          ],
+          "isUnique": true
+        },
+        "idx_round_votes_room": {
+          "name": "idx_round_votes_room",
+          "columns": [
+            "room_key"
+          ],
+          "isUnique": false
+        },
+        "idx_round_votes_ended": {
+          "name": "idx_round_votes_ended",
+          "columns": [
+            "round_ended_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "vote_records": {
+      "name": "vote_records",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "round_id": {
+          "name": "round_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "vote": {
+          "name": "vote",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "structured_vote_payload": {
+          "name": "structured_vote_payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "voted_at": {
+          "name": "voted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_vote_records_round": {
+          "name": "idx_vote_records_round",
+          "columns": [
+            "round_id"
+          ],
+          "isUnique": false
+        },
+        "idx_vote_records_user": {
+          "name": "idx_vote_records_user",
+          "columns": [
+            "user_name"
+          ],
+          "isUnique": false
+        },
+        "vote_records_round_user": {
+          "name": "vote_records_round_user",
+          "columns": [
+            "round_id",
+            "user_name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "vote_records_round_id_round_votes_round_id_fk": {
+          "name": "vote_records_round_id_round_votes_round_id_fk",
+          "tableFrom": "vote_records",
+          "tableTo": "round_votes",
+          "columnsFrom": [
+            "round_id"
+          ],
+          "columnsTo": [
+            "round_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "room_stats": {
+      "name": "room_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "room_key": {
+          "name": "room_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_rounds": {
+          "name": "total_rounds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_votes": {
+          "name": "total_votes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_updated_at": {
+          "name": "last_updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "room_stats_room_key_unique": {
+          "name": "room_stats_room_key_unique",
+          "columns": [
+            "room_key"
+          ],
+          "isUnique": true
+        },
+        "idx_room_stats_key": {
+          "name": "idx_room_stats_key",
+          "columns": [
+            "room_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/auth-worker/drizzle/meta/_journal.json
+++ b/apps/auth-worker/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1767898035212,
       "tag": "0001_nice_white_tiger",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1768182260881,
+      "tag": "0002_wandering_johnny_storm",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/room-worker/src/controllers/external/github-oauth-controller.ts
+++ b/apps/room-worker/src/controllers/external/github-oauth-controller.ts
@@ -10,6 +10,7 @@ import {
   escapeHtml,
   signState,
   verifyState,
+  generateID,
 } from '@sprintjam/utils';
 
 function jsonResponse(payload: unknown, status = 200): CfResponse {
@@ -81,7 +82,7 @@ export async function initiateGithubOAuthController(
     }
 
     const state = await signState(
-      { roomKey, userName, nonce: crypto.randomUUID() },
+      { roomKey, userName, nonce: generateID() },
       clientSecret
     );
 

--- a/apps/room-worker/src/controllers/external/jira-oauth-controller.ts
+++ b/apps/room-worker/src/controllers/external/jira-oauth-controller.ts
@@ -8,6 +8,7 @@ import {
   getRoomStub,
   escapeHtml,
   signState,
+  generateID,
   verifyState,
 } from '@sprintjam/utils';
 import {
@@ -19,7 +20,7 @@ import {
 function jsonResponse(payload: unknown, status = 200): CfResponse {
   return new Response(JSON.stringify(payload), {
     status,
-    headers: { "Content-Type": "application/json" },
+    headers: { 'Content-Type': 'application/json' },
   }) as unknown as CfResponse;
 }
 
@@ -84,7 +85,7 @@ export async function initiateJiraOAuthController(
     }
 
     const state = await signState(
-      { roomKey, userName, nonce: crypto.randomUUID() },
+      { roomKey, userName, nonce: generateID() },
       env.JIRA_OAUTH_CLIENT_SECRET
     );
 

--- a/apps/room-worker/src/controllers/external/linear-oauth-controller.ts
+++ b/apps/room-worker/src/controllers/external/linear-oauth-controller.ts
@@ -9,6 +9,7 @@ import {
   escapeHtml,
   signState,
   verifyState,
+  generateID,
 } from '@sprintjam/utils';
 import { getLinearOrganization, getLinearViewer } from '@sprintjam/services';
 
@@ -80,7 +81,7 @@ export async function initiateLinearOAuthController(
     }
 
     const state = await signState(
-      { roomKey, userName, nonce: crypto.randomUUID() },
+      { roomKey, userName, nonce: generateID() },
       env.LINEAR_OAUTH_CLIENT_SECRET
     );
 

--- a/apps/room-worker/src/lib/stats-client.ts
+++ b/apps/room-worker/src/lib/stats-client.ts
@@ -1,0 +1,51 @@
+import type { Fetcher } from "@cloudflare/workers-types";
+import type { JudgeMetadata } from "@sprintjam/types";
+
+export interface RoundStatsPayload {
+  roomKey: string;
+  roundId: string;
+  ticketId?: string;
+  votes: {
+    userName: string;
+    vote: string;
+    structuredVote?: object;
+    votedAt: number;
+  }[];
+  judgeScore?: string;
+  judgeMetadata?: JudgeMetadata;
+  roundEndedAt: number;
+}
+
+export async function postRoundStats(
+  statsWorker: Fetcher,
+  token: string | undefined,
+  data: RoundStatsPayload,
+): Promise<void> {
+  if (!token) {
+    console.warn("[stats-client] No STATS_INGEST_TOKEN configured, skipping");
+    return;
+  }
+
+  try {
+    const response = await statsWorker.fetch(
+      "https://stats-worker/ingest/round",
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(data),
+      },
+    );
+
+    if (!response.ok) {
+      const text = await response.text();
+      console.error(
+        `[stats-client] Failed to post stats: ${response.status} ${text}`,
+      );
+    }
+  } catch (error) {
+    console.error("[stats-client] Error posting stats:", error);
+  }
+}

--- a/apps/room-worker/wrangler.jsonc
+++ b/apps/room-worker/wrangler.jsonc
@@ -40,6 +40,12 @@
       },
     },
   ],
+  "services": [
+    {
+      "binding": "STATS_WORKER",
+      "service": "sprintjam-stats-worker",
+    },
+  ],
   "observability": {
     "enabled": true,
     "head_sampling_rate": 1,
@@ -63,6 +69,12 @@
         ],
       },
       "ratelimits": [],
+      "services": [
+        {
+          "binding": "STATS_WORKER",
+          "service": "sprintjam-stats-worker-development",
+        },
+      ],
     },
     "staging": {
       "vars": {
@@ -84,6 +96,12 @@
             "limit": 5,
             "period": 60,
           },
+        },
+      ],
+      "services": [
+        {
+          "binding": "STATS_WORKER",
+          "service": "sprintjam-stats-worker-staging",
         },
       ],
     },

--- a/apps/stats-worker/package.json
+++ b/apps/stats-worker/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@sprintjam/stats-worker",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "deploy:staging": "wrangler deploy --env staging",
+    "deploy:prod": "wrangler deploy",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
+    "generate:types": "wrangler types --include-runtime=false"
+  },
+  "dependencies": {
+    "@sprintjam/db": "workspace:*",
+    "@sprintjam/types": "workspace:*",
+    "@sprintjam/utils": "workspace:*",
+    "drizzle-orm": "0.45.1"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "4.20260107.1",
+    "@vitest/coverage-v8": "4.0.16",
+    "typescript": "5.9.3",
+    "vitest": "4.0.16",
+    "wrangler": "4.57.0"
+  }
+}

--- a/apps/stats-worker/src/index.ts
+++ b/apps/stats-worker/src/index.ts
@@ -1,0 +1,94 @@
+import type {
+  Request as CfRequest,
+  Response as CfResponse,
+} from "@cloudflare/workers-types";
+import type { StatsWorkerEnv } from "@sprintjam/types";
+import { WorkerEntrypoint } from "cloudflare:workers";
+
+import { ingestRoundController } from "./routes/ingest";
+import {
+  getRoomStatsController,
+  getUserRoomStatsController,
+  getBatchRoomStatsController,
+  getTeamStatsController,
+} from "./routes/query";
+
+async function handleRequest(
+  request: CfRequest,
+  env: StatsWorkerEnv,
+): Promise<CfResponse> {
+  try {
+    const url = new URL(request.url);
+    const path = url.pathname.startsWith("/api/")
+      ? url.pathname.substring(5)
+      : url.pathname.substring(1);
+
+    if (path === "" || path === "/") {
+      return new Response(
+        JSON.stringify({
+          status: "success",
+          message: "Sprintjam Stats Worker is running.",
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      ) as unknown as CfResponse;
+    }
+
+    if (path === "ingest/round" && request.method === "POST") {
+      return ingestRoundController(request, env);
+    }
+
+    const roomStatsMatch = path.match(/^stats\/room\/([^/]+)$/);
+    if (roomStatsMatch && request.method === "GET") {
+      return getRoomStatsController(request, env, roomStatsMatch[1]);
+    }
+
+    const userRoomStatsMatch = path.match(
+      /^stats\/room\/([^/]+)\/user\/([^/]+)$/,
+    );
+    if (userRoomStatsMatch && request.method === "GET") {
+      return getUserRoomStatsController(
+        request,
+        env,
+        userRoomStatsMatch[1],
+        decodeURIComponent(userRoomStatsMatch[2]),
+      );
+    }
+
+    if (path === "stats/rooms" && request.method === "GET") {
+      return getBatchRoomStatsController(request, env);
+    }
+
+    const teamStatsMatch = path.match(/^stats\/team\/(\d+)$/);
+    if (teamStatsMatch && request.method === "GET") {
+      return getTeamStatsController(
+        request,
+        env,
+        parseInt(teamStatsMatch[1], 10),
+      );
+    }
+
+    return new Response(JSON.stringify({ error: "Stats Route Not found" }), {
+      status: 404,
+      headers: { "Content-Type": "application/json" },
+    }) as unknown as CfResponse;
+  } catch (error) {
+    console.error("[stats-worker] handleRequest errored:", error);
+    return new Response(
+      JSON.stringify({ error: "[stats-worker] Internal Server Error" }),
+      {
+        status: 500,
+        headers: { "Content-Type": "application/json" },
+      },
+    ) as unknown as CfResponse;
+  }
+}
+
+export default class extends WorkerEntrypoint {
+  async fetch(request: CfRequest): Promise<CfResponse> {
+    const env = this.env as StatsWorkerEnv;
+    return handleRequest(request, env);
+  }
+}

--- a/apps/stats-worker/src/lib/auth.ts
+++ b/apps/stats-worker/src/lib/auth.ts
@@ -1,0 +1,135 @@
+import type {
+  Request as CfRequest,
+  D1Database,
+} from '@cloudflare/workers-types';
+import { getSessionTokenFromRequest, hashToken } from '@sprintjam/utils';
+import { drizzle } from 'drizzle-orm/d1';
+import { eq, and, gt, inArray } from 'drizzle-orm';
+import { workspaceSessions, users, teams, teamSessions } from '@sprintjam/db';
+
+export interface AuthResult {
+  userId: number;
+  email: string;
+  organisationId: number;
+}
+
+export interface AuthError {
+  status: 'error';
+  code: 'unauthorized' | 'expired';
+}
+
+export async function authenticateRequest(
+  request: CfRequest,
+  db: D1Database
+): Promise<AuthResult | AuthError> {
+  const token = getSessionTokenFromRequest(request);
+  if (!token) {
+    return { status: 'error', code: 'unauthorized' };
+  }
+
+  const tokenHash = await hashToken(token);
+  const drizzleDb = drizzle(db);
+  const now = Math.floor(Date.now() / 1000);
+
+  const result = await drizzleDb
+    .select({
+      userId: workspaceSessions.userId,
+      email: users.email,
+      organisationId: users.organisationId,
+    })
+    .from(workspaceSessions)
+    .innerJoin(users, eq(workspaceSessions.userId, users.id))
+    .where(
+      and(
+        eq(workspaceSessions.tokenHash, tokenHash),
+        gt(workspaceSessions.expiresAt, now)
+      )
+    )
+    .get();
+
+  if (!result) {
+    return { status: 'error', code: 'expired' };
+  }
+
+  return {
+    userId: result.userId,
+    email: result.email,
+    organisationId: result.organisationId,
+  };
+}
+
+export async function isUserInTeam(
+  db: D1Database,
+  userId: number,
+  teamId: number
+): Promise<boolean> {
+  const drizzleDb = drizzle(db);
+
+  const user = await drizzleDb
+    .select({ organisationId: users.organisationId })
+    .from(users)
+    .where(eq(users.id, userId))
+    .get();
+
+  if (!user) return false;
+
+  const team = await drizzleDb
+    .select({ organisationId: teams.organisationId })
+    .from(teams)
+    .where(eq(teams.id, teamId))
+    .get();
+
+  if (!team) return false;
+
+  return user.organisationId === team.organisationId;
+}
+
+export async function canUserAccessRoom(
+  db: D1Database,
+  organisationId: number,
+  roomKey: string
+): Promise<boolean> {
+  const drizzleDb = drizzle(db);
+
+  const session = await drizzleDb
+    .select({
+      teamId: teamSessions.teamId,
+      organisationId: teams.organisationId,
+    })
+    .from(teamSessions)
+    .innerJoin(teams, eq(teamSessions.teamId, teams.id))
+    .where(eq(teamSessions.roomKey, roomKey))
+    .get();
+
+  if (!session) {
+    return false;
+  }
+
+  return session.organisationId === organisationId;
+}
+
+export async function filterAccessibleRoomKeys(
+  db: D1Database,
+  organisationId: number,
+  roomKeys: string[]
+): Promise<string[]> {
+  if (roomKeys.length === 0) return [];
+
+  const drizzleDb = drizzle(db);
+
+  const accessibleSessions = await drizzleDb
+    .select({
+      roomKey: teamSessions.roomKey,
+    })
+    .from(teamSessions)
+    .innerJoin(teams, eq(teamSessions.teamId, teams.id))
+    .where(
+      and(
+        inArray(teamSessions.roomKey, roomKeys),
+        eq(teams.organisationId, organisationId)
+      )
+    )
+    .all();
+
+  return accessibleSessions.map((s) => s.roomKey);
+}

--- a/apps/stats-worker/src/repositories/stats.ts
+++ b/apps/stats-worker/src/repositories/stats.ts
@@ -1,0 +1,314 @@
+import type { D1Database } from "@cloudflare/workers-types";
+import { eq, sql, and, inArray } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/d1";
+
+import {
+  roundVotes,
+  voteRecords,
+  roomStats,
+  teamSessions,
+} from "@sprintjam/db/d1/schemas";
+
+export interface RoundIngestData {
+  roomKey: string;
+  roundId: string;
+  ticketId?: string;
+  votes: {
+    userName: string;
+    vote: string;
+    structuredVote?: object;
+    votedAt: number;
+  }[];
+  judgeScore?: string;
+  judgeMetadata?: object;
+  roundEndedAt: number;
+}
+
+export interface RoomStatsResult {
+  roomKey: string;
+  totalRounds: number;
+  totalVotes: number;
+  lastUpdatedAt: number;
+}
+
+export interface UserRoomStatsResult {
+  userName: string;
+  totalVotes: number;
+  participationRate: number;
+  consensusAlignment: number;
+  judgeAlignment: number;
+  voteDistribution: Record<string, number>;
+}
+
+export interface TeamStatsResult {
+  totalMembers: number;
+  totalRounds: number;
+  avgParticipation: number;
+  consensusRate: number;
+  memberStats: UserRoomStatsResult[];
+}
+
+export class StatsRepository {
+  private db;
+
+  constructor(d1: D1Database) {
+    this.db = drizzle(d1);
+  }
+
+  async ingestRound(data: RoundIngestData): Promise<void> {
+    const now = Math.floor(Date.now() / 1000);
+
+    await this.db.insert(roundVotes).values({
+      roomKey: data.roomKey,
+      roundId: data.roundId,
+      ticketId: data.ticketId ?? null,
+      judgeScore: data.judgeScore ?? null,
+      judgeMetadata: data.judgeMetadata
+        ? JSON.stringify(data.judgeMetadata)
+        : null,
+      roundEndedAt: data.roundEndedAt,
+      createdAt: now,
+    });
+
+    if (data.votes.length > 0) {
+      await this.db.insert(voteRecords).values(
+        data.votes.map((v) => ({
+          roundId: data.roundId,
+          userName: v.userName,
+          vote: v.vote,
+          structuredVotePayload: v.structuredVote
+            ? JSON.stringify(v.structuredVote)
+            : null,
+          votedAt: v.votedAt,
+        })),
+      );
+    }
+
+    await this.updateRoomStats(data.roomKey, data.votes.length);
+  }
+
+  private async updateRoomStats(
+    roomKey: string,
+    newVotes: number,
+  ): Promise<void> {
+    const now = Math.floor(Date.now() / 1000);
+
+    const existing = await this.db
+      .select()
+      .from(roomStats)
+      .where(eq(roomStats.roomKey, roomKey))
+      .get();
+
+    if (existing) {
+      await this.db
+        .update(roomStats)
+        .set({
+          totalRounds: existing.totalRounds + 1,
+          totalVotes: existing.totalVotes + newVotes,
+          lastUpdatedAt: now,
+        })
+        .where(eq(roomStats.roomKey, roomKey));
+    } else {
+      await this.db.insert(roomStats).values({
+        roomKey,
+        totalRounds: 1,
+        totalVotes: newVotes,
+        lastUpdatedAt: now,
+      });
+    }
+  }
+
+  async getRoomStats(roomKey: string): Promise<RoomStatsResult | null> {
+    const result = await this.db
+      .select()
+      .from(roomStats)
+      .where(eq(roomStats.roomKey, roomKey))
+      .get();
+
+    if (!result) return null;
+
+    return {
+      roomKey: result.roomKey,
+      totalRounds: result.totalRounds,
+      totalVotes: result.totalVotes,
+      lastUpdatedAt: result.lastUpdatedAt,
+    };
+  }
+
+  async getBatchRoomStats(
+    roomKeys: string[],
+  ): Promise<Map<string, RoomStatsResult>> {
+    if (roomKeys.length === 0) return new Map();
+
+    const results = await this.db
+      .select()
+      .from(roomStats)
+      .where(inArray(roomStats.roomKey, roomKeys))
+      .all();
+
+    const map = new Map<string, RoomStatsResult>();
+    for (const r of results) {
+      map.set(r.roomKey, {
+        roomKey: r.roomKey,
+        totalRounds: r.totalRounds,
+        totalVotes: r.totalVotes,
+        lastUpdatedAt: r.lastUpdatedAt,
+      });
+    }
+    return map;
+  }
+
+  async getUserRoomStats(
+    roomKey: string,
+    userName: string,
+  ): Promise<UserRoomStatsResult | null> {
+    const rounds = await this.db
+      .select()
+      .from(roundVotes)
+      .where(eq(roundVotes.roomKey, roomKey))
+      .all();
+
+    if (rounds.length === 0) return null;
+
+    const roundIds = rounds.map((r) => r.roundId);
+    const userVotes = await this.db
+      .select()
+      .from(voteRecords)
+      .where(
+        and(
+          inArray(voteRecords.roundId, roundIds),
+          eq(voteRecords.userName, userName),
+        ),
+      )
+      .all();
+
+    if (userVotes.length === 0) return null;
+
+    const voteDistribution: Record<string, number> = {};
+    let judgeMatches = 0;
+    let judgeComparisons = 0;
+
+    for (const vote of userVotes) {
+      voteDistribution[vote.vote] = (voteDistribution[vote.vote] || 0) + 1;
+
+      const round = rounds.find((r) => r.roundId === vote.roundId);
+      if (round?.judgeScore) {
+        judgeComparisons++;
+        if (vote.vote === round.judgeScore) {
+          judgeMatches++;
+        }
+      }
+    }
+
+    const allVotesForRounds = await this.db
+      .select()
+      .from(voteRecords)
+      .where(inArray(voteRecords.roundId, roundIds))
+      .all();
+
+    let consensusMatches = 0;
+    for (const vote of userVotes) {
+      const roundVotesForRound = allVotesForRounds.filter(
+        (v) => v.roundId === vote.roundId,
+      );
+      const voteCounts: Record<string, number> = {};
+      for (const v of roundVotesForRound) {
+        voteCounts[v.vote] = (voteCounts[v.vote] || 0) + 1;
+      }
+      const consensus = Object.entries(voteCounts).sort(
+        (a, b) => b[1] - a[1],
+      )[0]?.[0];
+      if (vote.vote === consensus) {
+        consensusMatches++;
+      }
+    }
+
+    return {
+      userName,
+      totalVotes: userVotes.length,
+      participationRate: (userVotes.length / rounds.length) * 100,
+      consensusAlignment:
+        userVotes.length > 0 ? (consensusMatches / userVotes.length) * 100 : 0,
+      judgeAlignment:
+        judgeComparisons > 0 ? (judgeMatches / judgeComparisons) * 100 : 0,
+      voteDistribution,
+    };
+  }
+
+  async getTeamStats(teamId: number): Promise<TeamStatsResult | null> {
+    const sessions = await this.db
+      .select()
+      .from(teamSessions)
+      .where(eq(teamSessions.teamId, teamId))
+      .all();
+
+    if (sessions.length === 0) return null;
+
+    const roomKeys = sessions.map((s) => s.roomKey);
+    const stats = await this.getBatchRoomStats(roomKeys);
+
+    let totalRounds = 0;
+    let totalVotes = 0;
+    for (const s of stats.values()) {
+      totalRounds += s.totalRounds;
+      totalVotes += s.totalVotes;
+    }
+
+    const rounds = await this.db
+      .select()
+      .from(roundVotes)
+      .where(inArray(roundVotes.roomKey, roomKeys))
+      .all();
+
+    const roundIds = rounds.map((r) => r.roundId);
+    const allVotes =
+      roundIds.length > 0
+        ? await this.db
+            .select()
+            .from(voteRecords)
+            .where(inArray(voteRecords.roundId, roundIds))
+            .all()
+        : [];
+
+    const memberVoteCounts = new Map<string, number>();
+    for (const vote of allVotes) {
+      memberVoteCounts.set(
+        vote.userName,
+        (memberVoteCounts.get(vote.userName) || 0) + 1,
+      );
+    }
+
+    const memberStats: UserRoomStatsResult[] = [];
+    for (const [userName, voteCount] of memberVoteCounts) {
+      const userVotes = allVotes.filter((v) => v.userName === userName);
+      const voteDistribution: Record<string, number> = {};
+      for (const v of userVotes) {
+        voteDistribution[v.vote] = (voteDistribution[v.vote] || 0) + 1;
+      }
+
+      memberStats.push({
+        userName,
+        totalVotes: voteCount,
+        participationRate:
+          totalRounds > 0 ? (voteCount / totalRounds) * 100 : 0,
+        consensusAlignment: 0,
+        judgeAlignment: 0,
+        voteDistribution,
+      });
+    }
+
+    const avgParticipation =
+      memberStats.length > 0
+        ? memberStats.reduce((sum, m) => sum + m.participationRate, 0) /
+          memberStats.length
+        : 0;
+
+    return {
+      totalMembers: memberStats.length,
+      totalRounds,
+      avgParticipation,
+      consensusRate: 0,
+      memberStats,
+    };
+  }
+}

--- a/apps/stats-worker/src/routes/ingest.test.ts
+++ b/apps/stats-worker/src/routes/ingest.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { StatsWorkerEnv } from "@sprintjam/types";
+
+import { ingestRoundController } from "./ingest";
+import { StatsRepository } from "../repositories/stats";
+
+vi.mock("../repositories/stats", () => ({
+  StatsRepository: vi.fn(),
+}));
+
+describe("ingestRoundController", () => {
+  let mockEnv: StatsWorkerEnv;
+  let mockRepo: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEnv = {
+      DB: {} as any,
+      STATS_INGEST_TOKEN: "test-secret-token",
+    } as StatsWorkerEnv;
+
+    mockRepo = {
+      ingestRound: vi.fn(),
+    };
+
+    vi.mocked(StatsRepository).mockImplementation(function () {
+      return mockRepo;
+    });
+  });
+
+  it("should return 401 when no authorization header", async () => {
+    const request = new Request("https://test.com/ingest/round", {
+      method: "POST",
+      body: JSON.stringify({}),
+    });
+
+    const response = await ingestRoundController(request as any, mockEnv);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  it("should return 401 when token is invalid", async () => {
+    const request = new Request("https://test.com/ingest/round", {
+      method: "POST",
+      headers: { Authorization: "Bearer wrong-token" },
+      body: JSON.stringify({}),
+    });
+
+    const response = await ingestRoundController(request as any, mockEnv);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  it("should return 400 when required fields are missing", async () => {
+    const request = new Request("https://test.com/ingest/round", {
+      method: "POST",
+      headers: { Authorization: "Bearer test-secret-token" },
+      body: JSON.stringify({ roomKey: "room1" }),
+    });
+
+    const response = await ingestRoundController(request as any, mockEnv);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe("Missing required fields");
+  });
+
+  it("should return 400 when roundId is missing", async () => {
+    const request = new Request("https://test.com/ingest/round", {
+      method: "POST",
+      headers: { Authorization: "Bearer test-secret-token" },
+      body: JSON.stringify({
+        roomKey: "room1",
+        votes: [],
+        roundEndedAt: 1700000000,
+      }),
+    });
+
+    const response = await ingestRoundController(request as any, mockEnv);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe("Missing required fields");
+  });
+
+  it("should successfully ingest round data", async () => {
+    mockRepo.ingestRound.mockResolvedValue(undefined);
+
+    const request = new Request("https://test.com/ingest/round", {
+      method: "POST",
+      headers: { Authorization: "Bearer test-secret-token" },
+      body: JSON.stringify({
+        roomKey: "room1",
+        roundId: "round-uuid-123",
+        votes: [
+          { userName: "alice", vote: "5", votedAt: 1700000000 },
+          { userName: "bob", vote: "3", votedAt: 1700000001 },
+        ],
+        roundEndedAt: 1700000010,
+      }),
+    });
+
+    const response = await ingestRoundController(request as any, mockEnv);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(mockRepo.ingestRound).toHaveBeenCalledWith({
+      roomKey: "room1",
+      roundId: "round-uuid-123",
+      ticketId: undefined,
+      votes: [
+        { userName: "alice", vote: "5", votedAt: 1700000000 },
+        { userName: "bob", vote: "3", votedAt: 1700000001 },
+      ],
+      judgeScore: undefined,
+      judgeMetadata: undefined,
+      roundEndedAt: 1700000010,
+    });
+  });
+
+  it("should include optional fields when provided", async () => {
+    mockRepo.ingestRound.mockResolvedValue(undefined);
+
+    const request = new Request("https://test.com/ingest/round", {
+      method: "POST",
+      headers: { Authorization: "Bearer test-secret-token" },
+      body: JSON.stringify({
+        roomKey: "room1",
+        roundId: "round-uuid-123",
+        ticketId: "TICKET-1",
+        votes: [{ userName: "alice", vote: "5", votedAt: 1700000000 }],
+        judgeScore: "5",
+        judgeMetadata: { confidence: 0.8, reasoning: "High consensus" },
+        roundEndedAt: 1700000010,
+      }),
+    });
+
+    const response = await ingestRoundController(request as any, mockEnv);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(mockRepo.ingestRound).toHaveBeenCalledWith({
+      roomKey: "room1",
+      roundId: "round-uuid-123",
+      ticketId: "TICKET-1",
+      votes: [{ userName: "alice", vote: "5", votedAt: 1700000000 }],
+      judgeScore: "5",
+      judgeMetadata: { confidence: 0.8, reasoning: "High consensus" },
+      roundEndedAt: 1700000010,
+    });
+  });
+
+  it("should handle empty votes array", async () => {
+    mockRepo.ingestRound.mockResolvedValue(undefined);
+
+    const request = new Request("https://test.com/ingest/round", {
+      method: "POST",
+      headers: { Authorization: "Bearer test-secret-token" },
+      body: JSON.stringify({
+        roomKey: "room1",
+        roundId: "round-uuid-123",
+        votes: [],
+        roundEndedAt: 1700000010,
+      }),
+    });
+
+    const response = await ingestRoundController(request as any, mockEnv);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+  });
+});

--- a/apps/stats-worker/src/routes/ingest.ts
+++ b/apps/stats-worker/src/routes/ingest.ts
@@ -1,0 +1,69 @@
+import type {
+  Request as CfRequest,
+  Response as CfResponse,
+} from "@cloudflare/workers-types";
+import type { StatsWorkerEnv } from "@sprintjam/types";
+
+import { StatsRepository, type RoundIngestData } from "../repositories/stats";
+
+interface RoundIngestPayload {
+  roomKey: string;
+  roundId: string;
+  ticketId?: string;
+  votes: {
+    userName: string;
+    vote: string;
+    structuredVote?: object;
+    votedAt: number;
+  }[];
+  judgeScore?: string;
+  judgeMetadata?: object;
+  roundEndedAt: number;
+}
+
+function validateToken(request: CfRequest, env: StatsWorkerEnv): boolean {
+  const authHeader = request.headers.get("Authorization");
+  if (!authHeader?.startsWith("Bearer ")) return false;
+  const token = authHeader.substring(7);
+  return token === env.STATS_INGEST_TOKEN;
+}
+
+export async function ingestRoundController(
+  request: CfRequest,
+  env: StatsWorkerEnv,
+): Promise<CfResponse> {
+  if (!validateToken(request, env)) {
+    return new Response(JSON.stringify({ error: "Unauthorized" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    }) as unknown as CfResponse;
+  }
+
+  const body = (await request.json()) as RoundIngestPayload;
+
+  if (!body.roomKey || !body.roundId || !body.votes || !body.roundEndedAt) {
+    return new Response(JSON.stringify({ error: "Missing required fields" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    }) as unknown as CfResponse;
+  }
+
+  const repo = new StatsRepository(env.DB);
+
+  const data: RoundIngestData = {
+    roomKey: body.roomKey,
+    roundId: body.roundId,
+    ticketId: body.ticketId,
+    votes: body.votes,
+    judgeScore: body.judgeScore,
+    judgeMetadata: body.judgeMetadata,
+    roundEndedAt: body.roundEndedAt,
+  };
+
+  await repo.ingestRound(data);
+
+  return new Response(JSON.stringify({ success: true }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  }) as unknown as CfResponse;
+}

--- a/apps/stats-worker/src/routes/query.test.ts
+++ b/apps/stats-worker/src/routes/query.test.ts
@@ -1,0 +1,536 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { StatsWorkerEnv } from "@sprintjam/types";
+
+import {
+  getRoomStatsController,
+  getUserRoomStatsController,
+  getBatchRoomStatsController,
+  getTeamStatsController,
+} from "./query";
+import { StatsRepository } from "../repositories/stats";
+import * as auth from "../lib/auth";
+
+vi.mock("../repositories/stats", () => ({
+  StatsRepository: vi.fn(),
+}));
+vi.mock("../lib/auth", () => ({
+  authenticateRequest: vi.fn(),
+  isUserInTeam: vi.fn(),
+  canUserAccessRoom: vi.fn(),
+  filterAccessibleRoomKeys: vi.fn(),
+}));
+
+describe("getRoomStatsController", () => {
+  let mockEnv: StatsWorkerEnv;
+  let mockRepo: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEnv = { DB: {} as any } as StatsWorkerEnv;
+
+    mockRepo = {
+      getRoomStats: vi.fn(),
+    };
+
+    vi.mocked(StatsRepository).mockImplementation(function () {
+      return mockRepo;
+    });
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    vi.mocked(auth.authenticateRequest).mockResolvedValue({
+      status: "error",
+      code: "unauthorized",
+    });
+
+    const request = new Request("https://test.com/stats/room/test-room", {
+      method: "GET",
+    });
+
+    const response = await getRoomStatsController(
+      request as any,
+      mockEnv,
+      "test-room",
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  it("should return 403 when user does not have room access", async () => {
+    vi.mocked(auth.authenticateRequest).mockResolvedValue({
+      userId: 1,
+      email: "test@example.com",
+      organisationId: 1,
+    });
+    vi.mocked(auth.canUserAccessRoom).mockResolvedValue(false);
+
+    const request = new Request("https://test.com/stats/room/test-room", {
+      method: "GET",
+    });
+
+    const response = await getRoomStatsController(
+      request as any,
+      mockEnv,
+      "test-room",
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data.error).toBe("You do not have access to this room's stats");
+  });
+
+  it("should return 404 when room not found", async () => {
+    vi.mocked(auth.authenticateRequest).mockResolvedValue({
+      userId: 1,
+      email: "test@example.com",
+      organisationId: 1,
+    });
+    vi.mocked(auth.canUserAccessRoom).mockResolvedValue(true);
+    mockRepo.getRoomStats.mockResolvedValue(null);
+
+    const request = new Request("https://test.com/stats/room/test-room", {
+      method: "GET",
+    });
+
+    const response = await getRoomStatsController(
+      request as any,
+      mockEnv,
+      "test-room",
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.error).toBe("Room not found");
+  });
+
+  it("should return room stats when found", async () => {
+    vi.mocked(auth.authenticateRequest).mockResolvedValue({
+      userId: 1,
+      email: "test@example.com",
+      organisationId: 1,
+    });
+    vi.mocked(auth.canUserAccessRoom).mockResolvedValue(true);
+    mockRepo.getRoomStats.mockResolvedValue({
+      roomKey: "test-room",
+      totalRounds: 10,
+      totalVotes: 50,
+      lastUpdatedAt: 1700000000,
+    });
+
+    const request = new Request("https://test.com/stats/room/test-room", {
+      method: "GET",
+    });
+
+    const response = await getRoomStatsController(
+      request as any,
+      mockEnv,
+      "test-room",
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.stats.roomKey).toBe("test-room");
+    expect(data.stats.totalRounds).toBe(10);
+    expect(data.stats.totalVotes).toBe(50);
+  });
+});
+
+describe("getUserRoomStatsController", () => {
+  let mockEnv: StatsWorkerEnv;
+  let mockRepo: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEnv = { DB: {} as any } as StatsWorkerEnv;
+
+    mockRepo = {
+      getUserRoomStats: vi.fn(),
+    };
+
+    vi.mocked(StatsRepository).mockImplementation(function () {
+      return mockRepo;
+    });
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    vi.mocked(auth.authenticateRequest).mockResolvedValue({
+      status: "error",
+      code: "unauthorized",
+    });
+
+    const request = new Request(
+      "https://test.com/stats/room/test-room/user/alice",
+      {
+        method: "GET",
+      },
+    );
+
+    const response = await getUserRoomStatsController(
+      request as any,
+      mockEnv,
+      "test-room",
+      "alice",
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  it("should return 403 when user does not have room access", async () => {
+    vi.mocked(auth.authenticateRequest).mockResolvedValue({
+      userId: 1,
+      email: "test@example.com",
+      organisationId: 1,
+    });
+    vi.mocked(auth.canUserAccessRoom).mockResolvedValue(false);
+
+    const request = new Request(
+      "https://test.com/stats/room/test-room/user/alice",
+      {
+        method: "GET",
+      },
+    );
+
+    const response = await getUserRoomStatsController(
+      request as any,
+      mockEnv,
+      "test-room",
+      "alice",
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data.error).toBe("You do not have access to this room's stats");
+  });
+
+  it("should return 404 when user stats not found", async () => {
+    vi.mocked(auth.authenticateRequest).mockResolvedValue({
+      userId: 1,
+      email: "test@example.com",
+      organisationId: 1,
+    });
+    vi.mocked(auth.canUserAccessRoom).mockResolvedValue(true);
+    mockRepo.getUserRoomStats.mockResolvedValue(null);
+
+    const request = new Request(
+      "https://test.com/stats/room/test-room/user/alice",
+      {
+        method: "GET",
+      },
+    );
+
+    const response = await getUserRoomStatsController(
+      request as any,
+      mockEnv,
+      "test-room",
+      "alice",
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.error).toBe("User stats not found");
+  });
+
+  it("should return user room stats when found", async () => {
+    vi.mocked(auth.authenticateRequest).mockResolvedValue({
+      userId: 1,
+      email: "test@example.com",
+      organisationId: 1,
+    });
+    vi.mocked(auth.canUserAccessRoom).mockResolvedValue(true);
+    mockRepo.getUserRoomStats.mockResolvedValue({
+      userName: "alice",
+      totalVotes: 8,
+      participationRate: 80,
+      consensusAlignment: 75,
+      judgeAlignment: 60,
+      voteDistribution: { "3": 5, "5": 3 },
+    });
+
+    const request = new Request(
+      "https://test.com/stats/room/test-room/user/alice",
+      {
+        method: "GET",
+      },
+    );
+
+    const response = await getUserRoomStatsController(
+      request as any,
+      mockEnv,
+      "test-room",
+      "alice",
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.stats.userName).toBe("alice");
+    expect(data.stats.totalVotes).toBe(8);
+    expect(data.stats.participationRate).toBe(80);
+  });
+});
+
+describe("getBatchRoomStatsController", () => {
+  let mockEnv: StatsWorkerEnv;
+  let mockRepo: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEnv = { DB: {} as any } as StatsWorkerEnv;
+
+    mockRepo = {
+      getBatchRoomStats: vi.fn(),
+    };
+
+    vi.mocked(StatsRepository).mockImplementation(function () {
+      return mockRepo;
+    });
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    vi.mocked(auth.authenticateRequest).mockResolvedValue({
+      status: "error",
+      code: "unauthorized",
+    });
+
+    const request = new Request("https://test.com/stats/rooms?keys=room1", {
+      method: "GET",
+    });
+
+    const response = await getBatchRoomStatsController(request as any, mockEnv);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  it("should return 400 when keys parameter is missing", async () => {
+    vi.mocked(auth.authenticateRequest).mockResolvedValue({
+      userId: 1,
+      email: "test@example.com",
+      organisationId: 1,
+    });
+
+    const request = new Request("https://test.com/stats/rooms", {
+      method: "GET",
+    });
+
+    const response = await getBatchRoomStatsController(request as any, mockEnv);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.error).toBe("Missing keys query parameter");
+  });
+
+  it("should return batch room stats only for accessible rooms", async () => {
+    vi.mocked(auth.authenticateRequest).mockResolvedValue({
+      userId: 1,
+      email: "test@example.com",
+      organisationId: 1,
+    });
+    vi.mocked(auth.filterAccessibleRoomKeys).mockResolvedValue([
+      "room1",
+      "room2",
+    ]);
+
+    const statsMap = new Map([
+      [
+        "room1",
+        {
+          roomKey: "room1",
+          totalRounds: 5,
+          totalVotes: 25,
+          lastUpdatedAt: 1700000000,
+        },
+      ],
+      [
+        "room2",
+        {
+          roomKey: "room2",
+          totalRounds: 3,
+          totalVotes: 15,
+          lastUpdatedAt: 1700000000,
+        },
+      ],
+    ]);
+    mockRepo.getBatchRoomStats.mockResolvedValue(statsMap);
+
+    const request = new Request(
+      "https://test.com/stats/rooms?keys=room1,room2,room3",
+      {
+        method: "GET",
+      },
+    );
+
+    const response = await getBatchRoomStatsController(request as any, mockEnv);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.stats.room1.totalRounds).toBe(5);
+    expect(data.stats.room2.totalRounds).toBe(3);
+    expect(mockRepo.getBatchRoomStats).toHaveBeenCalledWith(["room1", "room2"]);
+    expect(auth.filterAccessibleRoomKeys).toHaveBeenCalledWith(mockEnv.DB, 1, [
+      "room1",
+      "room2",
+      "room3",
+    ]);
+  });
+
+  it("should return empty stats when user has no access to any rooms", async () => {
+    vi.mocked(auth.authenticateRequest).mockResolvedValue({
+      userId: 1,
+      email: "test@example.com",
+      organisationId: 1,
+    });
+    vi.mocked(auth.filterAccessibleRoomKeys).mockResolvedValue([]);
+    mockRepo.getBatchRoomStats.mockResolvedValue(new Map());
+
+    const request = new Request(
+      "https://test.com/stats/rooms?keys=room1,room2",
+      {
+        method: "GET",
+      },
+    );
+
+    const response = await getBatchRoomStatsController(request as any, mockEnv);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.stats).toEqual({});
+  });
+});
+
+describe("getTeamStatsController", () => {
+  let mockEnv: StatsWorkerEnv;
+  let mockRepo: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEnv = { DB: {} as any } as StatsWorkerEnv;
+
+    mockRepo = {
+      getTeamStats: vi.fn(),
+    };
+
+    vi.mocked(StatsRepository).mockImplementation(function () {
+      return mockRepo;
+    });
+  });
+
+  it("should return 401 when not authenticated", async () => {
+    vi.mocked(auth.authenticateRequest).mockResolvedValue({
+      status: "error",
+      code: "unauthorized",
+    });
+
+    const request = new Request("https://test.com/stats/team/1", {
+      method: "GET",
+    });
+
+    const response = await getTeamStatsController(request as any, mockEnv, 1);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  it("should return 401 when session expired", async () => {
+    vi.mocked(auth.authenticateRequest).mockResolvedValue({
+      status: "error",
+      code: "expired",
+    });
+
+    const request = new Request("https://test.com/stats/team/1", {
+      method: "GET",
+      headers: { Authorization: "Bearer expired-token" },
+    });
+
+    const response = await getTeamStatsController(request as any, mockEnv, 1);
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.error).toBe("Session expired");
+  });
+
+  it("should return 403 when user is not a team member", async () => {
+    vi.mocked(auth.authenticateRequest).mockResolvedValue({
+      userId: 1,
+      email: "test@example.com",
+      organisationId: 1,
+    });
+    vi.mocked(auth.isUserInTeam).mockResolvedValue(false);
+
+    const request = new Request("https://test.com/stats/team/1", {
+      method: "GET",
+      headers: { Authorization: "Bearer valid-token" },
+    });
+
+    const response = await getTeamStatsController(request as any, mockEnv, 1);
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data.error).toBe("You do not have access to this team's stats");
+  });
+
+  it("should return 404 when team stats not found", async () => {
+    vi.mocked(auth.authenticateRequest).mockResolvedValue({
+      userId: 1,
+      email: "test@example.com",
+      organisationId: 1,
+    });
+    vi.mocked(auth.isUserInTeam).mockResolvedValue(true);
+    mockRepo.getTeamStats.mockResolvedValue(null);
+
+    const request = new Request("https://test.com/stats/team/1", {
+      method: "GET",
+      headers: { Authorization: "Bearer valid-token" },
+    });
+
+    const response = await getTeamStatsController(request as any, mockEnv, 1);
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.error).toBe("Team stats not found");
+  });
+
+  it("should return team stats for authorized user", async () => {
+    vi.mocked(auth.authenticateRequest).mockResolvedValue({
+      userId: 1,
+      email: "test@example.com",
+      organisationId: 1,
+    });
+    vi.mocked(auth.isUserInTeam).mockResolvedValue(true);
+    mockRepo.getTeamStats.mockResolvedValue({
+      totalMembers: 5,
+      totalRounds: 20,
+      avgParticipation: 85,
+      consensusRate: 70,
+      memberStats: [
+        {
+          userName: "alice",
+          totalVotes: 18,
+          participationRate: 90,
+          consensusAlignment: 75,
+          judgeAlignment: 60,
+          voteDistribution: { "3": 10, "5": 8 },
+        },
+      ],
+    });
+
+    const request = new Request("https://test.com/stats/team/1", {
+      method: "GET",
+      headers: { Authorization: "Bearer valid-token" },
+    });
+
+    const response = await getTeamStatsController(request as any, mockEnv, 1);
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.stats.totalMembers).toBe(5);
+    expect(data.stats.totalRounds).toBe(20);
+    expect(data.stats.memberStats).toHaveLength(1);
+    expect(data.stats.memberStats[0].userName).toBe("alice");
+  });
+});

--- a/apps/stats-worker/src/routes/query.ts
+++ b/apps/stats-worker/src/routes/query.ts
@@ -1,0 +1,233 @@
+import type {
+  Request as CfRequest,
+  Response as CfResponse,
+} from "@cloudflare/workers-types";
+import type { StatsWorkerEnv } from "@sprintjam/types";
+
+import { StatsRepository } from "../repositories/stats";
+import {
+  authenticateRequest,
+  isUserInTeam,
+  canUserAccessRoom,
+  filterAccessibleRoomKeys,
+} from '../lib/auth';
+
+export async function getRoomStatsController(
+  request: CfRequest,
+  env: StatsWorkerEnv,
+  roomKey: string
+): Promise<CfResponse> {
+  const authResult = await authenticateRequest(request, env.DB);
+  if ('status' in authResult && authResult.status === 'error') {
+    return new Response(
+      JSON.stringify({
+        error:
+          authResult.code === 'unauthorized'
+            ? 'Unauthorized'
+            : 'Session expired',
+      }),
+      {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    ) as unknown as CfResponse;
+  }
+
+  const auth = authResult as {
+    userId: number;
+    email: string;
+    organisationId: number;
+  };
+  const hasAccess = await canUserAccessRoom(
+    env.DB,
+    auth.organisationId,
+    roomKey
+  );
+  if (!hasAccess) {
+    return new Response(
+      JSON.stringify({ error: "You do not have access to this room's stats" }),
+      {
+        status: 403,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    ) as unknown as CfResponse;
+  }
+
+  const repo = new StatsRepository(env.DB);
+  const stats = await repo.getRoomStats(roomKey);
+
+  if (!stats) {
+    return new Response(JSON.stringify({ error: 'Room not found' }), {
+      status: 404,
+      headers: { 'Content-Type': 'application/json' },
+    }) as unknown as CfResponse;
+  }
+
+  return new Response(JSON.stringify({ stats }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  }) as unknown as CfResponse;
+}
+
+export async function getUserRoomStatsController(
+  request: CfRequest,
+  env: StatsWorkerEnv,
+  roomKey: string,
+  userName: string
+): Promise<CfResponse> {
+  const authResult = await authenticateRequest(request, env.DB);
+  if ('status' in authResult && authResult.status === 'error') {
+    return new Response(
+      JSON.stringify({
+        error:
+          authResult.code === 'unauthorized'
+            ? 'Unauthorized'
+            : 'Session expired',
+      }),
+      {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    ) as unknown as CfResponse;
+  }
+
+  const auth = authResult as {
+    userId: number;
+    email: string;
+    organisationId: number;
+  };
+  const hasAccess = await canUserAccessRoom(
+    env.DB,
+    auth.organisationId,
+    roomKey
+  );
+  if (!hasAccess) {
+    return new Response(
+      JSON.stringify({ error: "You do not have access to this room's stats" }),
+      {
+        status: 403,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    ) as unknown as CfResponse;
+  }
+
+  const repo = new StatsRepository(env.DB);
+  const stats = await repo.getUserRoomStats(roomKey, userName);
+
+  if (!stats) {
+    return new Response(JSON.stringify({ error: 'User stats not found' }), {
+      status: 404,
+      headers: { 'Content-Type': 'application/json' },
+    }) as unknown as CfResponse;
+  }
+
+  return new Response(JSON.stringify({ stats }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  }) as unknown as CfResponse;
+}
+
+export async function getBatchRoomStatsController(
+  request: CfRequest,
+  env: StatsWorkerEnv
+): Promise<CfResponse> {
+  const authResult = await authenticateRequest(request, env.DB);
+  if ('status' in authResult && authResult.status === 'error') {
+    return new Response(
+      JSON.stringify({
+        error:
+          authResult.code === 'unauthorized'
+            ? 'Unauthorized'
+            : 'Session expired',
+      }),
+      {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    ) as unknown as CfResponse;
+  }
+
+  const url = new URL(request.url);
+  const keysParam = url.searchParams.get('keys');
+
+  if (!keysParam) {
+    return new Response(
+      JSON.stringify({ error: 'Missing keys query parameter' }),
+      {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    ) as unknown as CfResponse;
+  }
+
+  const roomKeys = keysParam.split(',').filter(Boolean);
+
+  const auth = authResult as {
+    userId: number;
+    email: string;
+    organisationId: number;
+  };
+  const accessibleRoomKeys = await filterAccessibleRoomKeys(
+    env.DB,
+    auth.organisationId,
+    roomKeys
+  );
+
+  const repo = new StatsRepository(env.DB);
+  const statsMap = await repo.getBatchRoomStats(accessibleRoomKeys);
+
+  const stats = Object.fromEntries(statsMap);
+
+  return new Response(JSON.stringify({ stats }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  }) as unknown as CfResponse;
+}
+
+export async function getTeamStatsController(
+  request: CfRequest,
+  env: StatsWorkerEnv,
+  teamId: number
+): Promise<CfResponse> {
+  const authResult = await authenticateRequest(request, env.DB);
+  if ('status' in authResult && authResult.status === 'error') {
+    return new Response(
+      JSON.stringify({
+        error:
+          authResult.code === 'unauthorized'
+            ? 'Unauthorized'
+            : 'Session expired',
+      }),
+      {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    ) as unknown as CfResponse;
+  }
+
+  const isMember = await isUserInTeam(env.DB, authResult.userId, teamId);
+  if (!isMember) {
+    return new Response(
+      JSON.stringify({ error: "You do not have access to this team's stats" }),
+      {
+        status: 403,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    ) as unknown as CfResponse;
+  }
+
+  const repo = new StatsRepository(env.DB);
+  const stats = await repo.getTeamStats(teamId);
+
+  if (!stats) {
+    return new Response(JSON.stringify({ error: 'Team stats not found' }), {
+      status: 404,
+      headers: { 'Content-Type': 'application/json' },
+    }) as unknown as CfResponse;
+  }
+
+  return new Response(JSON.stringify({ stats }), {
+    status: 200,
+    headers: { 'Content-Type': 'application/json' },
+  }) as unknown as CfResponse;
+}

--- a/apps/stats-worker/tsconfig.json
+++ b/apps/stats-worker/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "files": [],
+  "references": [
+    {
+      "path": "./tsconfig.worker.json"
+    }
+  ]
+}

--- a/apps/stats-worker/tsconfig.node.json
+++ b/apps/stats-worker/tsconfig.node.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/apps/stats-worker/tsconfig.worker.json
+++ b/apps/stats-worker/tsconfig.worker.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.node.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.worker.tsbuildinfo",
+    "types": ["@cloudflare/workers-types"]
+  },
+  "include": ["src"]
+}

--- a/apps/stats-worker/wrangler.jsonc
+++ b/apps/stats-worker/wrangler.jsonc
@@ -1,0 +1,56 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "sprintjam-stats-worker",
+  "main": "src/index.ts",
+  "compatibility_date": "2025-07-15",
+  "workers_dev": false,
+  "preview_urls": false,
+  "placement": {
+    "mode": "smart"
+  },
+  "vars": {
+    "ENVIRONMENT": "production"
+  },
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "sprintjam-workspaces",
+      "database_id": "683f5126-8f0f-492d-80a4-bea41ebce1ab"
+    }
+  ],
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1,
+    "logs": {
+      "enabled": true,
+      "head_sampling_rate": 1,
+      "invocation_logs": false
+    }
+  },
+  "env": {
+    "development": {
+      "vars": {
+        "ENVIRONMENT": "development"
+      },
+      "d1_databases": [
+        {
+          "binding": "DB",
+          "database_name": "sprintjam-workspaces-staging",
+          "database_id": "2f17f84f-02ad-4548-9b66-a9bfa1c54186"
+        }
+      ]
+    },
+    "staging": {
+      "vars": {
+        "ENVIRONMENT": "staging"
+      },
+      "d1_databases": [
+        {
+          "binding": "DB",
+          "database_name": "sprintjam-workspaces-staging",
+          "database_id": "2f17f84f-02ad-4548-9b66-a9bfa1c54186"
+        }
+      ]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "format:check": "prettier --check .",
     "test": "turbo test",
     "deploy": "turbo deploy",
-    "deploy:staging": "pnpm --filter @sprintjam/auth-worker deploy:staging && pnpm --filter @sprintjam/room-worker deploy:staging && pnpm --filter @sprintjam/app build:staging && pnpm --filter @sprintjam/app deploy:staging",
-    "deploy:prod": "pnpm --filter @sprintjam/auth-worker deploy:prod && pnpm --filter @sprintjam/room-worker deploy:prod && pnpm --filter @sprintjam/app build && pnpm --filter @sprintjam/app deploy:prod",
+    "deploy:staging": "pnpm --filter @sprintjam/auth-worker deploy:staging && pnpm --filter @sprintjam/room-worker deploy:staging && pnpm --filter @sprintjam/stats-worker deploy:staging && pnpm --filter @sprintjam/app build:staging && pnpm --filter @sprintjam/app deploy:staging",
+    "deploy:prod": "pnpm --filter @sprintjam/auth-worker deploy:prod && pnpm --filter @sprintjam/room-worker deploy:prod && pnpm --filter @sprintjam/stats-worker deploy:prod && pnpm --filter @sprintjam/app build && pnpm --filter @sprintjam/app deploy:prod",
     "db:migrate:local": "pnpm --filter @sprintjam/auth-worker db:migrate:local",
     "db:migrate:staging": "pnpm --filter @sprintjam/auth-worker db:migrate:staging",
     "db:migrate:prod": "pnpm --filter @sprintjam/auth-worker db:migrate:prod"

--- a/packages/db/src/d1/schemas/index.ts
+++ b/packages/db/src/d1/schemas/index.ts
@@ -5,3 +5,6 @@ export * from "./teams";
 export * from "./magic-links";
 export * from "./workspace-sessions";
 export * from "./team-sessions";
+export * from "./round-votes";
+export * from "./vote-records";
+export * from "./room-stats";

--- a/packages/db/src/d1/schemas/room-stats.ts
+++ b/packages/db/src/d1/schemas/room-stats.ts
@@ -1,0 +1,13 @@
+import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+export const roomStats = sqliteTable(
+  "room_stats",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    roomKey: text("room_key").notNull().unique(),
+    totalRounds: integer("total_rounds").notNull().default(0),
+    totalVotes: integer("total_votes").notNull().default(0),
+    lastUpdatedAt: integer("last_updated_at").notNull(),
+  },
+  (table) => [index("idx_room_stats_key").on(table.roomKey)],
+);

--- a/packages/db/src/d1/schemas/round-votes.ts
+++ b/packages/db/src/d1/schemas/round-votes.ts
@@ -1,0 +1,21 @@
+import { index, integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+export const roundVotes = sqliteTable(
+  "round_votes",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    roomKey: text("room_key").notNull(),
+    roundId: text("round_id").notNull().unique(),
+    ticketId: text("ticket_id"),
+    judgeScore: text("judge_score"),
+    judgeMetadata: text("judge_metadata"),
+    roundEndedAt: integer("round_ended_at").notNull(),
+    createdAt: integer("created_at")
+      .notNull()
+      .$defaultFn(() => Math.floor(Date.now() / 1000)),
+  },
+  (table) => [
+    index("idx_round_votes_room").on(table.roomKey),
+    index("idx_round_votes_ended").on(table.roundEndedAt),
+  ],
+);

--- a/packages/db/src/d1/schemas/vote-records.ts
+++ b/packages/db/src/d1/schemas/vote-records.ts
@@ -1,0 +1,28 @@
+import {
+  index,
+  integer,
+  sqliteTable,
+  text,
+  unique,
+} from "drizzle-orm/sqlite-core";
+
+import { roundVotes } from "./round-votes";
+
+export const voteRecords = sqliteTable(
+  "vote_records",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    roundId: text("round_id")
+      .notNull()
+      .references(() => roundVotes.roundId, { onDelete: "cascade" }),
+    userName: text("user_name").notNull(),
+    vote: text("vote").notNull(),
+    structuredVotePayload: text("structured_vote_payload"),
+    votedAt: integer("voted_at").notNull(),
+  },
+  (table) => [
+    unique("vote_records_round_user").on(table.roundId, table.userName),
+    index("idx_vote_records_round").on(table.roundId),
+    index("idx_vote_records_user").on(table.userName),
+  ],
+);

--- a/packages/types/src/env.ts
+++ b/packages/types/src/env.ts
@@ -20,6 +20,7 @@ export interface DispatchWorkerEnv extends BaseEnv {
   ASSETS: Fetcher;
   ROOM_WORKER: Fetcher;
   AUTH_WORKER: Fetcher;
+  STATS_WORKER: Fetcher;
 }
 
 /**
@@ -29,6 +30,8 @@ export interface RoomWorkerEnv extends BaseEnv {
   JOIN_RATE_LIMITER: RateLimit;
   PLANNING_ROOM: DurableObjectNamespace;
   TOKEN_ENCRYPTION_SECRET: string;
+  STATS_WORKER: Fetcher;
+  STATS_INGEST_TOKEN?: string;
   JIRA_OAUTH_CLIENT_ID?: string;
   JIRA_OAUTH_CLIENT_SECRET?: string;
   JIRA_OAUTH_REDIRECT_URI?: string;
@@ -50,4 +53,12 @@ export interface AuthWorkerEnv extends BaseEnv {
   RESEND_API_KEY: string;
   ENABLE_MAGIC_LINK_RATE_LIMIT?: string;
   MAGIC_LINK_RATE_LIMITER: RateLimit;
+}
+
+/**
+ * Environment for the stats worker
+ */
+export interface StatsWorkerEnv extends BaseEnv {
+  DB: D1Database;
+  STATS_INGEST_TOKEN: string;
 }

--- a/packages/utils/src/generate-id.ts
+++ b/packages/utils/src/generate-id.ts
@@ -1,0 +1,4 @@
+export function generateID() {
+  const id = crypto.randomUUID();
+  return id;
+}

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -19,3 +19,4 @@ export * from './token-crypto';
 export * from './validate';
 export * from './strudel';
 export * from './lib/polychat-client';
+export * from './generate-id';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,6 +192,37 @@ importers:
         specifier: 4.57.0
         version: 4.57.0(@cloudflare/workers-types@4.20260107.1)
 
+  apps/stats-worker:
+    dependencies:
+      '@sprintjam/db':
+        specifier: workspace:*
+        version: link:../../packages/db
+      '@sprintjam/types':
+        specifier: workspace:*
+        version: link:../../packages/types
+      '@sprintjam/utils':
+        specifier: workspace:*
+        version: link:../../packages/utils
+      drizzle-orm:
+        specifier: 0.45.1
+        version: 0.45.1(@cloudflare/workers-types@4.20260107.1)
+    devDependencies:
+      '@cloudflare/workers-types':
+        specifier: 4.20260107.1
+        version: 4.20260107.1
+      '@vitest/coverage-v8':
+        specifier: 4.0.16
+        version: 4.0.16(vitest@4.0.16(@types/node@25.0.3)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2))
+      typescript:
+        specifier: 5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: 4.0.16
+        version: 4.0.16(@types/node@25.0.3)(jiti@2.6.1)(jsdom@27.4.0)(lightningcss@1.30.2)
+      wrangler:
+        specifier: 4.57.0
+        version: 4.57.0(@cloudflare/workers-types@4.20260107.1)
+
   packages/db:
     dependencies:
       drizzle-orm:


### PR DESCRIPTION
Resolves #75

Adds a new stats worker to track room stats on round completions. Started work on joining this up to rooms and the frontend app.

TODO:

- Need to get the stats captured on next ticket click (the next ticket button from the modal) it only happens on completeTicket at the moment, which i don't think is actually being used...
- On complete session, the modal should be expanded to ensure that stats are saved for sessions that use the ticket queue and ones that don't. On session completion, the room will be closed and it will show the stats instead of the voting interface.
- Update the workspaces dashboard with stats functionality
- Ensure that stats can only be retrieved by a member of the team alone. _ Check security elsewhere to ensure their are proper permissions behind the data retrival.
- Update deploy scripts to deploy the stats worker
- Make sure it's all properly unit and e2e tested.