### PR TITLE
Modularize planning-room game engines and validate game types

### DIFF
--- a/apps/room-worker/src/durable-objects/planning-room/game-engines/helpers.ts
+++ b/apps/room-worker/src/durable-objects/planning-room/game-engines/helpers.ts
@@ -1,0 +1,83 @@
+import type { RoomData, RoomGameSession, RoomGameType } from "@sprintjam/types";
+
+import type { GameEngine } from "./types";
+
+export const MAX_GAME_ROUNDS = 5;
+export const ROUND_MOVE_TARGET = 6;
+export const GUESS_ROUND_ATTEMPT_LIMIT = 10;
+const MAX_EMOJI_STORY_MOVE_EMOJIS = 6;
+const EMOJI_TOKEN_PATTERN =
+  /(?:\p{Extended_Pictographic}(?:\uFE0F|\p{Emoji_Modifier})?(?:\u200D\p{Extended_Pictographic}(?:\uFE0F|\p{Emoji_Modifier})?)*|\p{Regional_Indicator}{2}|[0-9#*]\uFE0F?\u20E3)/gu;
+
+export const createNumberTarget = () => Math.floor(Math.random() * 20) + 1;
+
+export const createGameEvent = (message: string) => ({
+  id: `${Date.now()}-${Math.random().toString(16).slice(2, 8)}`,
+  message,
+  createdAt: Date.now(),
+});
+
+export const createGameMove = (
+  session: RoomGameSession,
+  userName: string,
+  value: string,
+) => ({
+  id: `${Date.now()}-${Math.random().toString(16).slice(2, 8)}`,
+  user: userName,
+  submittedAt: Date.now(),
+  value,
+  round: session.round,
+});
+
+export const addPoints = (
+  session: RoomGameSession,
+  userName: string,
+  points: number,
+) => {
+  session.leaderboard[userName] = (session.leaderboard[userName] ?? 0) + points;
+};
+
+export const addEvent = (session: RoomGameSession, message: string) => {
+  session.events = [...session.events.slice(-9), createGameEvent(message)];
+};
+
+export const getCurrentRoundMoveCount = (session: RoomGameSession) =>
+  session.moves.filter((gameMove) => gameMove.round === session.round).length;
+
+export const isValidEmojiStoryMove = (value: string) => {
+  const compactValue = value.replace(/\s+/g, "");
+  if (!compactValue) {
+    return false;
+  }
+
+  const emojiTokens = compactValue.match(EMOJI_TOKEN_PATTERN) ?? [];
+  if (
+    emojiTokens.length === 0 ||
+    emojiTokens.length > MAX_EMOJI_STORY_MOVE_EMOJIS
+  ) {
+    return false;
+  }
+
+  return emojiTokens.join("") === compactValue;
+};
+
+export const initializeGameSession = (
+  roomData: RoomData,
+  gameType: RoomGameType,
+  startedBy: string,
+  gameEngine: GameEngine,
+): RoomGameSession => ({
+  type: gameType,
+  startedBy,
+  startedAt: Date.now(),
+  round: 1,
+  status: "active",
+  participants: [...roomData.users],
+  leaderboard: roomData.users.reduce<Record<string, number>>((scores, user) => {
+    scores[user] = 0;
+    return scores;
+  }, {}),
+  moves: [],
+  events: [createGameEvent(`${startedBy} started ${gameEngine.title}.`)],
+  ...gameEngine.initializeSessionState(),
+});

--- a/apps/room-worker/src/durable-objects/planning-room/game-engines/registry.ts
+++ b/apps/room-worker/src/durable-objects/planning-room/game-engines/registry.ts
@@ -1,0 +1,141 @@
+import type { RoomGameType } from "@sprintjam/types";
+
+import {
+  GUESS_ROUND_ATTEMPT_LIMIT,
+  ROUND_MOVE_TARGET,
+  addEvent,
+  addPoints,
+  createNumberTarget,
+  getCurrentRoundMoveCount,
+  isValidEmojiStoryMove,
+} from "./helpers";
+import type { GameEngine } from "./types";
+
+export const GAME_ENGINES: Record<RoomGameType, GameEngine> = {
+  "guess-the-number": {
+    title: "Guess the Number",
+    initializeSessionState: () => ({ numberTarget: createNumberTarget() }),
+    applyMove: ({ session, userName, value, move }) => {
+      const guess = Number(value);
+      if (
+        !session.numberTarget ||
+        session.numberTarget < 1 ||
+        session.numberTarget > 20
+      ) {
+        session.numberTarget = createNumberTarget();
+      }
+      const target = session.numberTarget;
+
+      if (
+        Number.isFinite(guess) &&
+        Number.isInteger(guess) &&
+        guess >= 1 &&
+        guess <= 20
+      ) {
+        let isExactGuess = false;
+        const alreadyGuessedSameValueThisRound = session.moves.some(
+          (gameMove) =>
+            gameMove.id !== move.id &&
+            gameMove.round === move.round &&
+            gameMove.user === userName &&
+            gameMove.value === value,
+        );
+
+        if (alreadyGuessedSameValueThisRound) {
+          addEvent(
+            session,
+            `${userName} already guessed that number this wrong this round.`,
+          );
+        } else {
+          if (guess === target) {
+            isExactGuess = true;
+            addPoints(session, userName, 3);
+            addEvent(
+              session,
+              `${userName} nailed it with ${guess}. +3 points.`,
+            );
+            session.round += 1;
+            session.numberTarget = createNumberTarget();
+          } else if (Math.abs(guess - target) <= 2) {
+            addPoints(session, userName, 1);
+            addEvent(
+              session,
+              `${userName} was close with their guess. +1 point.`,
+            );
+          } else {
+            addEvent(
+              session,
+              `${userName} missed with their guess. No points.`,
+            );
+          }
+        }
+
+        if (
+          !isExactGuess &&
+          getCurrentRoundMoveCount(session) >= GUESS_ROUND_ATTEMPT_LIMIT
+        ) {
+          session.round += 1;
+          session.numberTarget = createNumberTarget();
+          addEvent(
+            session,
+            `Round ${session.round - 1} closed without an exact hit. New number, round ${session.round}.`,
+          );
+        }
+      } else {
+        session.moves = session.moves.slice(0, -1);
+        addEvent(
+          session,
+          `${userName} entered an invalid guess. Use a whole number from 1 to 20.`,
+        );
+      }
+    },
+  },
+  "word-chain": {
+    title: "Word Chain",
+    initializeSessionState: () => ({ lastWord: null }),
+    applyMove: ({ session, userName, value }) => {
+      const normalized = value.toLowerCase().replace(/[^a-z]/g, "");
+      const prior = session.lastWord ?? null;
+      const isValidWord = normalized.length >= 2;
+
+      if (isValidWord) {
+        if (!prior || normalized[0] === prior[prior.length - 1]) {
+          session.lastWord = normalized;
+          addPoints(session, userName, 2);
+          addEvent(
+            session,
+            `${userName} kept the chain alive with “${value}”. +2 points.`,
+          );
+        } else {
+          addEvent(session, `${userName} broke the chain with “${value}”.`);
+        }
+      } else {
+        session.moves = session.moves.slice(0, -1);
+        addEvent(
+          session,
+          `${userName} entered an invalid word. Use at least two letters.`,
+        );
+      }
+
+      if (
+        isValidWord &&
+        getCurrentRoundMoveCount(session) === ROUND_MOVE_TARGET
+      ) {
+        session.round += 1;
+      }
+    },
+  },
+  "emoji-story": {
+    title: "Emoji Story",
+    initializeSessionState: () => ({}),
+    isMoveValueValid: isValidEmojiStoryMove,
+    applyMove: ({ session, userName, value }) => {
+      addPoints(session, userName, 1);
+      addEvent(session, `${userName} added “${value}” to the story.`);
+
+      if (getCurrentRoundMoveCount(session) === ROUND_MOVE_TARGET) {
+        session.round += 1;
+      }
+    },
+  },
+};

--- a/apps/room-worker/src/durable-objects/planning-room/game-engines/types.ts
+++ b/apps/room-worker/src/durable-objects/planning-room/game-engines/types.ts
@@ -1,0 +1,15 @@
+import type { RoomGameSession } from "@sprintjam/types";
+
+export interface GameEngineMoveContext {
+  session: RoomGameSession;
+  userName: string;
+  value: string;
+  move: RoomGameSession["moves"][number];
+}
+
+export interface GameEngine {
+  title: string;
+  initializeSessionState: () => Partial<RoomGameSession>;
+  isMoveValueValid?: (value: string) => boolean;
+  applyMove: (context: GameEngineMoveContext) => void;
+}

--- a/apps/room-worker/src/durable-objects/planning-room/games.ts
+++ b/apps/room-worker/src/durable-objects/planning-room/games.ts
@@ -1,82 +1,28 @@
-import type { RoomData, RoomGameSession, RoomGameType } from '@sprintjam/types';
-import { sanitizeGameSession } from '@sprintjam/utils';
+import type { RoomData, RoomGameSession, RoomGameType } from "@sprintjam/types";
+import { sanitizeGameSession } from "@sprintjam/utils";
 
-import type { PlanningRoom } from '.';
-
-const GAME_TITLES: Record<RoomGameType, string> = {
-  'guess-the-number': 'Guess the Number',
-  'word-chain': 'Word Chain',
-  'emoji-story': 'Emoji Story',
-};
-const MAX_GAME_ROUNDS = 5;
-const ROUND_MOVE_TARGET = 6;
-const GUESS_ROUND_ATTEMPT_LIMIT = 10;
-const MAX_EMOJI_STORY_MOVE_EMOJIS = 6;
-const EMOJI_TOKEN_PATTERN =
-  /(?:\p{Extended_Pictographic}(?:\uFE0F|\p{Emoji_Modifier})?(?:\u200D\p{Extended_Pictographic}(?:\uFE0F|\p{Emoji_Modifier})?)*|\p{Regional_Indicator}{2}|[0-9#*]\uFE0F?\u20E3)/gu;
-const createNumberTarget = () => Math.floor(Math.random() * 20) + 1;
-
-const createGameEvent = (message: string) => ({
-  id: `${Date.now()}-${Math.random().toString(16).slice(2, 8)}`,
-  message,
-  createdAt: Date.now(),
-});
-
-const initializeSession = (
-  roomData: RoomData,
-  gameType: RoomGameType,
-  startedBy: string,
-): RoomGameSession => ({
-  type: gameType,
-  startedBy,
-  startedAt: Date.now(),
-  round: 1,
-  status: 'active',
-  participants: [...roomData.users],
-  leaderboard: roomData.users.reduce<Record<string, number>>((scores, user) => {
-    scores[user] = 0;
-    return scores;
-  }, {}),
-  moves: [],
-  events: [createGameEvent(`${startedBy} started ${GAME_TITLES[gameType]}.`)],
-  ...(gameType === 'guess-the-number' ? { numberTarget: createNumberTarget() } : {}),
-  ...(gameType === 'word-chain' ? { lastWord: null } : {}),
-});
-
-const addPoints = (session: RoomGameSession, userName: string, points: number) => {
-  session.leaderboard[userName] = (session.leaderboard[userName] ?? 0) + points;
-};
-
-const addEvent = (session: RoomGameSession, message: string) => {
-  session.events = [...session.events.slice(-9), createGameEvent(message)];
-};
-
-const getCurrentRoundMoveCount = (session: RoomGameSession) =>
-  session.moves.filter((gameMove) => gameMove.round === session.round).length;
-
-const isValidEmojiStoryMove = (value: string) => {
-  const compactValue = value.replace(/\s+/g, '');
-  if (!compactValue) {
-    return false;
-  }
-
-  const emojiTokens = compactValue.match(EMOJI_TOKEN_PATTERN) ?? [];
-  if (emojiTokens.length === 0 || emojiTokens.length > MAX_EMOJI_STORY_MOVE_EMOJIS) {
-    return false;
-  }
-
-  return emojiTokens.join('') === compactValue;
-};
+import type { PlanningRoom } from ".";
+import {
+  MAX_GAME_ROUNDS,
+  addEvent,
+  createGameMove,
+  initializeGameSession,
+} from "./game-engines/helpers";
+import { GAME_ENGINES } from "./game-engines/registry";
 
 const getWinner = (session: RoomGameSession) => {
-  const sortedScores = Object.entries(session.leaderboard).sort((a, b) => b[1] - a[1]);
+  const sortedScores = Object.entries(session.leaderboard).sort(
+    (a, b) => b[1] - a[1],
+  );
   const topScore = sortedScores[0]?.[1];
 
   if (topScore === undefined) {
     return undefined;
   }
 
-  const topScorers = sortedScores.filter(([, score]) => score === topScore).map(([name]) => name);
+  const topScorers = sortedScores
+    .filter(([, score]) => score === topScore)
+    .map(([name]) => name);
   return topScorers.length === 1 ? topScorers[0] : undefined;
 };
 
@@ -88,13 +34,13 @@ const completeGameSession = async (
   roomData: RoomData,
   session: RoomGameSession,
   endedBy: string,
-  reason: 'manual' | 'round-limit',
+  reason: "manual" | "round-limit",
 ) => {
   const winner = getWinner(session);
-  session.status = 'completed';
+  session.status = "completed";
   session.winner = winner;
 
-  if (reason === 'round-limit') {
+  if (reason === "round-limit") {
     addEvent(
       session,
       winner
@@ -114,7 +60,7 @@ const completeGameSession = async (
   await room.putRoomData(roomData);
 
   room.broadcast({
-    type: 'gameEnded',
+    type: "gameEnded",
     gameSession: getClientGameSession(session),
     endedBy,
   });
@@ -130,21 +76,28 @@ export async function handleStartGame(
     return;
   }
 
-  if (roomData.gameSession?.status === 'active') {
+  if (roomData.gameSession?.status === "active") {
     room.broadcast({
-      type: 'error',
-      error: 'A game is already running. End it before starting another one.',
-      reason: 'permission',
+      type: "error",
+      error: "A game is already running. End it before starting another one.",
+      reason: "permission",
     });
     return;
   }
 
-  const session = initializeSession(roomData, gameType, userName);
+  const gameEngine = GAME_ENGINES[gameType];
+  const session = initializeGameSession(
+    roomData,
+    gameType,
+    userName,
+    gameEngine,
+  );
+
   roomData.gameSession = session;
   await room.putRoomData(roomData);
 
   room.broadcast({
-    type: 'gameStarted',
+    type: "gameStarted",
     gameSession: getClientGameSession(session),
     startedBy: userName,
   });
@@ -158,7 +111,7 @@ export async function handleSubmitGameMove(
   const roomData = await room.getRoomData();
   const session = roomData?.gameSession;
 
-  if (!roomData || !session || session.status !== 'active') {
+  if (!roomData || !session || session.status !== "active") {
     return;
   }
 
@@ -167,7 +120,8 @@ export async function handleSubmitGameMove(
     return;
   }
 
-  if (session.type === 'emoji-story' && !isValidEmojiStoryMove(value)) {
+  const gameEngine = GAME_ENGINES[session.type];
+  if (gameEngine.isMoveValueValid && !gameEngine.isMoveValueValid(value)) {
     return;
   }
 
@@ -176,104 +130,13 @@ export async function handleSubmitGameMove(
     return;
   }
 
-  const move = {
-    id: `${Date.now()}-${Math.random().toString(16).slice(2, 8)}`,
-    user: userName,
-    submittedAt: Date.now(),
-    value,
-    round: session.round,
-  };
-
+  const move = createGameMove(session, userName, value);
   session.moves = [...session.moves.slice(-29), move];
 
-  if (session.type === 'guess-the-number') {
-    const guess = Number(value);
-    if (!session.numberTarget || session.numberTarget < 1 || session.numberTarget > 20) {
-      session.numberTarget = createNumberTarget();
-    }
-    const target = session.numberTarget;
-
-    if (Number.isFinite(guess) && Number.isInteger(guess) && guess >= 1 && guess <= 20) {
-      let isExactGuess = false;
-      const alreadyGuessedSameValueThisRound = session.moves.some(
-        (gameMove) =>
-          gameMove.id !== move.id &&
-          gameMove.round === move.round &&
-          gameMove.user === userName &&
-          gameMove.value === value,
-      );
-
-      if (alreadyGuessedSameValueThisRound) {
-        addEvent(
-          session,
-          `${userName} already guessed that number this wrong this round.`,
-        );
-      } else {
-        if (guess === target) {
-          isExactGuess = true;
-          addPoints(session, userName, 3);
-          addEvent(session, `${userName} nailed it with ${guess}. +3 points.`);
-          session.round += 1;
-          session.numberTarget = createNumberTarget();
-        } else if (Math.abs(guess - target) <= 2) {
-          addPoints(session, userName, 1);
-          addEvent(
-            session,
-            `${userName} was close with their guess. +1 point.`,
-          );
-        } else {
-          addEvent(session, `${userName} missed with their guess. No points.`);
-        }
-      }
-
-      if (!isExactGuess && getCurrentRoundMoveCount(session) >= GUESS_ROUND_ATTEMPT_LIMIT) {
-        session.round += 1;
-        session.numberTarget = createNumberTarget();
-        addEvent(
-          session,
-          `Round ${session.round - 1} closed without an exact hit. New number, round ${session.round}.`,
-        );
-      }
-    } else {
-      session.moves = session.moves.slice(0, -1);
-      addEvent(session, `${userName} entered an invalid guess. Use a whole number from 1 to 20.`);
-    }
-  }
-
-  if (session.type === 'word-chain') {
-    const normalized = value.toLowerCase().replace(/[^a-z]/g, '');
-    const prior = session.lastWord ?? null;
-    const isValidWord = normalized.length >= 2;
-
-    if (isValidWord) {
-      if (!prior || normalized[0] === prior[prior.length - 1]) {
-        session.lastWord = normalized;
-        addPoints(session, userName, 2);
-        addEvent(session, `${userName} kept the chain alive with “${value}”. +2 points.`);
-      } else {
-        addEvent(session, `${userName} broke the chain with “${value}”.`);
-      }
-    } else {
-      session.moves = session.moves.slice(0, -1);
-      addEvent(session, `${userName} entered an invalid word. Use at least two letters.`);
-    }
-
-    if (isValidWord && getCurrentRoundMoveCount(session) === ROUND_MOVE_TARGET) {
-      session.round += 1;
-    }
-  }
-
-  if (session.type === 'emoji-story') {
-    addPoints(session, userName, 1);
-    addEvent(session, `${userName} added “${value}” to the story.`);
-
-    if (getCurrentRoundMoveCount(session) === ROUND_MOVE_TARGET) {
-      session.round += 1;
-    }
-  }
+  gameEngine.applyMove({ session, userName, value, move });
 
   if (session.round > MAX_GAME_ROUNDS) {
-    await completeGameSession(room, roomData, session, 'system', 'round-limit');
+    await completeGameSession(room, roomData, session, "system", "round-limit");
     return;
   }
 
@@ -281,7 +144,7 @@ export async function handleSubmitGameMove(
   await room.putRoomData(roomData);
 
   room.broadcast({
-    type: 'gameMoveSubmitted',
+    type: "gameMoveSubmitted",
     gameSession: getClientGameSession(session),
     user: userName,
   });
@@ -291,9 +154,9 @@ export async function handleEndGame(room: PlanningRoom, userName: string) {
   const roomData = await room.getRoomData();
   const session = roomData?.gameSession;
 
-  if (!roomData || !session || session.status !== 'active') {
+  if (!roomData || !session || session.status !== "active") {
     return;
   }
 
-  await completeGameSession(room, roomData, session, userName, 'manual');
+  await completeGameSession(room, roomData, session, userName, "manual");
 }

--- a/packages/types/src/room.ts
+++ b/packages/types/src/room.ts
@@ -183,22 +183,22 @@ export interface TicketQueueItem {
   ticketId: string;
   title: string;
   description?: string;
-  status?: 'pending' | 'in_progress' | 'blocked' | 'completed';
+  status?: "pending" | "in_progress" | "blocked" | "completed";
   outcome?: string | null;
   createdAt: number;
   completedAt?: number | null;
   ordinal: number;
   externalService:
-    | 'jira'
-    | 'linear'
-    | 'github'
-    | 'clickup'
-    | 'asana'
-    | 'youtrack'
-    | 'zoho'
-    | 'trello'
-    | 'monday'
-    | 'none';
+    | "jira"
+    | "linear"
+    | "github"
+    | "clickup"
+    | "asana"
+    | "youtrack"
+    | "zoho"
+    | "trello"
+    | "monday"
+    | "none";
   externalServiceId?: string | null;
   externalServiceMetadata?: string | null;
 }
@@ -216,7 +216,13 @@ export interface TimerState {
   autoResetOnVotesReset?: boolean;
 }
 
-export type RoomGameType = 'guess-the-number' | 'word-chain' | 'emoji-story';
+export const ROOM_GAME_TYPES = [
+  "guess-the-number",
+  "word-chain",
+  "emoji-story",
+] as const;
+
+export type RoomGameType = (typeof ROOM_GAME_TYPES)[number];
 
 export interface RoomGameDefinition {
   type: RoomGameType;
@@ -245,7 +251,7 @@ export interface RoomGameSession {
   startedBy: string;
   startedAt: number;
   round: number;
-  status: 'active' | 'completed';
+  status: "active" | "completed";
   participants: string[];
   leaderboard: Record<string, number>;
   moves: RoomGameMove[];
@@ -255,7 +261,7 @@ export interface RoomGameSession {
   winner?: string;
 }
 
-export type RoomStatus = 'active' | 'completed';
+export type RoomStatus = "active" | "completed";
 
 export interface VotingCompletion {
   allVotesComplete: boolean;

--- a/packages/utils/src/validate.ts
+++ b/packages/utils/src/validate.ts
@@ -1,147 +1,156 @@
-import { ClientMessage } from '@sprintjam/types';
+import { ClientMessage, ROOM_GAME_TYPES } from "@sprintjam/types";
 
 function isObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
+  return typeof value === "object" && value !== null;
+}
+
+function isRoomGameType(
+  value: unknown,
+): value is (typeof ROOM_GAME_TYPES)[number] {
+  return (
+    typeof value === "string" &&
+    ROOM_GAME_TYPES.includes(value as (typeof ROOM_GAME_TYPES)[number])
+  );
 }
 
 export function validateClientMessage(
   data: unknown,
 ): ClientMessage | { error: string } {
-  if (!isObject(data) || typeof data.type !== 'string') {
-    return { error: 'Invalid message format' };
+  if (!isObject(data) || typeof data.type !== "string") {
+    return { error: "Invalid message format" };
   }
 
   switch (data.type) {
-    case 'vote':
-      if ('vote' in data) {
-        return { type: 'vote', vote: data.vote as string | number };
+    case "vote":
+      if ("vote" in data) {
+        return { type: "vote", vote: data.vote as string | number };
       }
-      return { error: 'Vote payload missing' };
-    case 'showVotes':
-      return { type: 'showVotes' };
-    case 'resetVotes':
-      return { type: 'resetVotes' };
-    case 'updateSettings':
-      if ('settings' in data && isObject(data.settings)) {
-        return { type: 'updateSettings', settings: data.settings };
+      return { error: "Vote payload missing" };
+    case "showVotes":
+      return { type: "showVotes" };
+    case "resetVotes":
+      return { type: "resetVotes" };
+    case "updateSettings":
+      if ("settings" in data && isObject(data.settings)) {
+        return { type: "updateSettings", settings: data.settings };
       }
-      return { error: 'Settings payload missing' };
-    case 'generateStrudelCode':
-      return { type: 'generateStrudelCode' };
-    case 'toggleStrudelPlayback':
-      return { type: 'toggleStrudelPlayback' };
-    case 'selectTicket':
-      if (typeof data.ticketId === 'number') {
-        return { type: 'selectTicket', ticketId: data.ticketId };
+      return { error: "Settings payload missing" };
+    case "generateStrudelCode":
+      return { type: "generateStrudelCode" };
+    case "toggleStrudelPlayback":
+      return { type: "toggleStrudelPlayback" };
+    case "selectTicket":
+      if (typeof data.ticketId === "number") {
+        return { type: "selectTicket", ticketId: data.ticketId };
       }
-      return { error: 'Select ticket payload invalid' };
-    case 'nextTicket':
-      return { type: 'nextTicket' };
-    case 'addTicket':
-      if ('ticket' in data && isObject(data.ticket)) {
+      return { error: "Select ticket payload invalid" };
+    case "nextTicket":
+      return { type: "nextTicket" };
+    case "addTicket":
+      if ("ticket" in data && isObject(data.ticket)) {
         const ticket = data.ticket;
         if (
           ticket.title !== undefined &&
-          typeof ticket.title !== 'string' &&
+          typeof ticket.title !== "string" &&
           ticket.title !== null
         ) {
-          return { error: 'Ticket title must be a string or null' };
+          return { error: "Ticket title must be a string or null" };
         }
         if (
           ticket.description !== undefined &&
-          typeof ticket.description !== 'string' &&
+          typeof ticket.description !== "string" &&
           ticket.description !== null
         ) {
-          return { error: 'Ticket description must be a string or null' };
+          return { error: "Ticket description must be a string or null" };
         }
         if (
           ticket.title &&
-          typeof ticket.title === 'string' &&
+          typeof ticket.title === "string" &&
           ticket.title.length > 500
         ) {
-          return { error: 'Ticket title too long (max 500 chars)' };
+          return { error: "Ticket title too long (max 500 chars)" };
         }
         if (
           ticket.description &&
-          typeof ticket.description === 'string' &&
+          typeof ticket.description === "string" &&
           ticket.description.length > 10000
         ) {
-          return { error: 'Ticket description too long (max 10000 chars)' };
+          return { error: "Ticket description too long (max 10000 chars)" };
         }
         if (
           ticket.externalServiceMetadata !== undefined &&
           ticket.externalServiceMetadata !== null &&
-          typeof ticket.externalServiceMetadata === 'string' &&
+          typeof ticket.externalServiceMetadata === "string" &&
           ticket.externalServiceMetadata.length > 10000
         ) {
-          return { error: 'Ticket metadata too long (max 10000 chars)' };
+          return { error: "Ticket metadata too long (max 10000 chars)" };
         }
-        return { type: 'addTicket', ticket: data.ticket };
+        return { type: "addTicket", ticket: data.ticket };
       }
-      return { error: 'Ticket payload missing' };
-    case 'updateTicket':
+      return { error: "Ticket payload missing" };
+    case "updateTicket":
       if (
-        typeof data.ticketId === 'number' &&
-        'updates' in data &&
+        typeof data.ticketId === "number" &&
+        "updates" in data &&
         isObject(data.updates)
       ) {
         const updates = data.updates;
         if (
           updates.title !== undefined &&
-          typeof updates.title !== 'string' &&
+          typeof updates.title !== "string" &&
           updates.title !== null
         ) {
-          return { error: 'Ticket title must be a string or null' };
+          return { error: "Ticket title must be a string or null" };
         }
         if (
           updates.description !== undefined &&
-          typeof updates.description !== 'string' &&
+          typeof updates.description !== "string" &&
           updates.description !== null
         ) {
-          return { error: 'Ticket description must be a string or null' };
+          return { error: "Ticket description must be a string or null" };
         }
         if (
           updates.title &&
-          typeof updates.title === 'string' &&
+          typeof updates.title === "string" &&
           updates.title.length > 500
         ) {
-          return { error: 'Ticket title too long (max 500 chars)' };
+          return { error: "Ticket title too long (max 500 chars)" };
         }
         if (
           updates.description &&
-          typeof updates.description === 'string' &&
+          typeof updates.description === "string" &&
           updates.description.length > 10000
         ) {
-          return { error: 'Ticket description too long (max 10000 chars)' };
+          return { error: "Ticket description too long (max 10000 chars)" };
         }
         if (
           updates.externalServiceMetadata !== undefined &&
           updates.externalServiceMetadata !== null &&
-          typeof updates.externalServiceMetadata === 'string' &&
+          typeof updates.externalServiceMetadata === "string" &&
           updates.externalServiceMetadata.length > 10000
         ) {
-          return { error: 'Ticket metadata too long (max 10000 chars)' };
+          return { error: "Ticket metadata too long (max 10000 chars)" };
         }
         return {
-          type: 'updateTicket',
+          type: "updateTicket",
           ticketId: data.ticketId,
           updates: data.updates,
         };
       }
-      return { error: 'Ticket update payload invalid' };
-    case 'deleteTicket':
-      if (typeof data.ticketId === 'number') {
-        return { type: 'deleteTicket', ticketId: data.ticketId };
+      return { error: "Ticket update payload invalid" };
+    case "deleteTicket":
+      if (typeof data.ticketId === "number") {
+        return { type: "deleteTicket", ticketId: data.ticketId };
       }
-      return { error: 'Ticket delete payload invalid' };
-    case 'startTimer':
-      return { type: 'startTimer' };
-    case 'pauseTimer':
-      return { type: 'pauseTimer' };
-    case 'resetTimer':
-      return { type: 'resetTimer' };
-    case 'configureTimer':
-      if ('config' in data && isObject(data.config)) {
+      return { error: "Ticket delete payload invalid" };
+    case "startTimer":
+      return { type: "startTimer" };
+    case "pauseTimer":
+      return { type: "pauseTimer" };
+    case "resetTimer":
+      return { type: "resetTimer" };
+    case "configureTimer":
+      if ("config" in data && isObject(data.config)) {
         const configInput = data.config;
         const config: {
           targetDurationSeconds?: number;
@@ -150,52 +159,51 @@ export function validateClientMessage(
         } = {};
 
         if (
-          'targetDurationSeconds' in configInput &&
-          typeof configInput.targetDurationSeconds === 'number'
+          "targetDurationSeconds" in configInput &&
+          typeof configInput.targetDurationSeconds === "number"
         ) {
           config.targetDurationSeconds = configInput.targetDurationSeconds;
         }
         if (
-          'autoResetOnVotesReset' in configInput &&
-          typeof configInput.autoResetOnVotesReset === 'boolean'
+          "autoResetOnVotesReset" in configInput &&
+          typeof configInput.autoResetOnVotesReset === "boolean"
         ) {
           config.autoResetOnVotesReset = configInput.autoResetOnVotesReset;
         }
         if (
-          'resetCountdown' in configInput &&
-          typeof configInput.resetCountdown === 'boolean'
+          "resetCountdown" in configInput &&
+          typeof configInput.resetCountdown === "boolean"
         ) {
           config.resetCountdown = configInput.resetCountdown;
         }
-        return { type: 'configureTimer', config };
+        return { type: "configureTimer", config };
       }
-      return { error: 'Timer config payload missing' };
-    case 'toggleSpectator':
-      if (typeof data.isSpectator === 'boolean') {
-        return { type: 'toggleSpectator', isSpectator: data.isSpectator };
+      return { error: "Timer config payload missing" };
+    case "toggleSpectator":
+      if (typeof data.isSpectator === "boolean") {
+        return { type: "toggleSpectator", isSpectator: data.isSpectator };
       }
-      return { error: 'toggleSpectator payload invalid' };
-    case 'completeSession':
-      return { type: 'completeSession' };
-    case 'startGame':
-      if (
-        data.gameType === 'guess-the-number' ||
-        data.gameType === 'word-chain' ||
-        data.gameType === 'emoji-story'
-      ) {
-        return { type: 'startGame', gameType: data.gameType };
+      return { error: "toggleSpectator payload invalid" };
+    case "completeSession":
+      return { type: "completeSession" };
+    case "startGame":
+      if (isRoomGameType(data.gameType)) {
+        return { type: "startGame", gameType: data.gameType };
       }
-      return { error: 'startGame payload invalid' };
-    case 'submitGameMove':
-      if (typeof data.value === 'string' && data.value.trim().length > 0) {
-        return { type: 'submitGameMove', value: data.value.trim().slice(0, 48) };
+      return { error: "startGame payload invalid" };
+    case "submitGameMove":
+      if (typeof data.value === "string" && data.value.trim().length > 0) {
+        return {
+          type: "submitGameMove",
+          value: data.value.trim().slice(0, 48),
+        };
       }
-      return { error: 'submitGameMove payload invalid' };
-    case 'endGame':
-      return { type: 'endGame' };
-    case 'ping':
-      return { type: 'ping' };
+      return { error: "submitGameMove payload invalid" };
+    case "endGame":
+      return { type: "endGame" };
+    case "ping":
+      return { type: "ping" };
     default:
-      return { error: 'Unknown message type' };
+      return { error: "Unknown message type" };
   }
 }


### PR DESCRIPTION
### Motivation
- Split monolithic game logic into modular pieces to make game engines extensible and easier to maintain.
- Centralize shared game utilities and constants for reuse across game implementations.
- Strengthen runtime validation of client messages for game-related payloads by using a canonical list of game types.

### Description
- Introduce a `game-engines` module with `helpers.ts`, `registry.ts`, and `types.ts` to encapsulate game engine APIs, shared helpers, and engine registry, and move constants and logic from `games.ts` into these files.
- Refactor `games.ts` to use `GAME_ENGINES` and helper functions such as `initializeGameSession`, `createGameMove`, and `addEvent`, delegating per-game move validation and application to the registry.
- Update shared types in `packages/types/src/room.ts` to export a `ROOM_GAME_TYPES` const array and derive `RoomGameType` from it, and normalize some union string literal quoting.
- Update `packages/utils/src/validate.ts` to use `ROOM_GAME_TYPES` and add `isRoomGameType` for validating `startGame` payloads, plus minor code style/quoting cleanups.

### Testing
- Ran the TypeScript build via `yarn build` which completed successfully.
- Executed unit tests via `yarn test` and all tests passed.
- Ran the project's linting/checks and no new errors were reported.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998ec4470c4832abbb02109859e8b5b)