### PR TITLE
Add Slack workspace integration for team OAuth

### DIFF
--- a/apps/app/src/routes/integrations.tsx
+++ b/apps/app/src/routes/integrations.tsx
@@ -3,6 +3,7 @@ import {
   ArrowUpRight,
   GitBranch,
   LayoutTemplate,
+  MessageSquare,
   ShieldCheck,
   Sparkles,
   Workflow,
@@ -81,6 +82,19 @@ const highlights = [
   },
 ];
 
+const chatIntegrations = [
+  {
+    name: "Microsoft Teams",
+    description:
+      "Launch SprintJam from a Teams tab, chat, channel, or meeting and keep the room tied to the right workspace team.",
+  },
+  {
+    name: "Slack",
+    description:
+      "Run SprintJam from a Slack channel, connect that channel to a workspace team, and bring teammates back to active planning rooms.",
+  },
+];
+
 const IntegrationsRoute = () => {
   const { startCreateFlow, startJoinFlow } = useSessionActions();
   const navigateTo = useAppNavigation();
@@ -134,6 +148,32 @@ const IntegrationsRoute = () => {
                     <ArrowUpRight className="h-4 w-4" />
                   </button>
                 </div>
+              </SurfaceCard>
+            ))}
+          </div>
+        </div>
+
+        <div className="space-y-6">
+          <div className="text-left">
+            <p className="text-sm font-semibold uppercase tracking-[0.25em] text-brand-600">
+              Chat apps
+            </p>
+            <h2 className="text-2xl font-semibold text-slate-900 dark:text-white">
+              Start sessions where the conversation already happens
+            </h2>
+          </div>
+          <div className="grid gap-4 md:grid-cols-2">
+            {chatIntegrations.map(({ name, description }) => (
+              <SurfaceCard key={name} className="h-full text-left">
+                <MarketingCardHeading
+                  icon={<MessageSquare />}
+                  size="lg"
+                >
+                  {name}
+                </MarketingCardHeading>
+                <p className="mt-2 text-sm text-slate-600 dark:text-slate-300">
+                  {description}
+                </p>
               </SurfaceCard>
             ))}
           </div>

--- a/apps/app/src/routes/workspace/admin/teams/settings.tsx
+++ b/apps/app/src/routes/workspace/admin/teams/settings.tsx
@@ -157,6 +157,7 @@ export default function WorkspaceTeamSettings() {
   const jiraOAuth = useTeamOAuth(selectedTeamId, "jira");
   const linearOAuth = useTeamOAuth(selectedTeamId, "linear");
   const githubOAuth = useTeamOAuth(selectedTeamId, "github");
+  const slackOAuth = useTeamOAuth(selectedTeamId, "slack");
 
   const collaborationQuery = useQuery<TeamCollaborationInstallation[]>({
     queryKey: collaborationQueryKey,
@@ -782,6 +783,36 @@ export default function WorkspaceTeamSettings() {
                       : undefined
                   }
                 />
+
+                <IntegrationRow
+                  label="Slack"
+                  description="Install the public Slack app for commands and channel updates"
+                  status={slackOAuth.status}
+                  loading={slackOAuth.loading}
+                  error={slackOAuth.error}
+                  disabled={!canManageTeam}
+                  onConnect={slackOAuth.connect}
+                  onDisconnect={slackOAuth.disconnect}
+                  metadata={
+                    slackOAuth.status.connected
+                      ? [
+                          metaStr(slackOAuth.status.metadata, "slackTeamName"),
+                          metaStr(
+                            slackOAuth.status.metadata,
+                            "slackEnterpriseName",
+                          ),
+                          metaStr(
+                            slackOAuth.status.metadata,
+                            "slackBotUserId",
+                          )
+                            ? `Bot: ${metaStr(slackOAuth.status.metadata, "slackBotUserId")}`
+                            : undefined,
+                        ]
+                          .filter(Boolean)
+                          .join(" · ") || undefined
+                      : undefined
+                  }
+                />
               </SurfaceCard>
 
               <SurfaceCard className="flex flex-col gap-4">
@@ -797,7 +828,7 @@ export default function WorkspaceTeamSettings() {
 
                 <div className="rounded-lg border border-blue-200 bg-blue-50/70 p-4 dark:border-blue-900/40 dark:bg-blue-950/20">
                   <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-                    <div className="space-y-3">
+                    <div className="grid gap-4 md:grid-cols-2">
                       <div>
                         <p className="text-sm font-semibold text-blue-950 dark:text-blue-200">
                           How to connect Microsoft Teams
@@ -807,6 +838,16 @@ export default function WorkspaceTeamSettings() {
                           open it from the channel, chat, or meeting you want to
                           connect. Then sign in, select this workspace team, and
                           connect it.
+                        </p>
+                      </div>
+                      <div>
+                        <p className="text-sm font-semibold text-blue-950 dark:text-blue-200">
+                          How to connect Slack
+                        </p>
+                        <p className="mt-1 text-xs text-blue-900 dark:text-blue-300">
+                          Connect Slack in team integrations above. The public
+                          Slack app can then use commands and channel actions
+                          against this team&apos;s encrypted Slack installation.
                         </p>
                       </div>
                     </div>
@@ -849,9 +890,9 @@ export default function WorkspaceTeamSettings() {
                           No collaboration apps connected
                         </p>
                         <p className="text-xs text-slate-500 dark:text-slate-400">
-                          Add the SprintJam Teams app and open the launch tab to
-                          connect a channel, chat, or meeting to this workspace
-                          team.
+                          Open the SprintJam Teams app from a shared
+                          conversation, or connect Slack above before using
+                          Slack commands and channel updates for this team.
                         </p>
                       </div>
                     </div>
@@ -937,6 +978,9 @@ function getCollaborationLabel(installation: TeamCollaborationInstallation) {
   if (installation.displayName) {
     return installation.displayName;
   }
+  if (installation.platform === "slack") {
+    return installation.externalChannelId ? "Slack channel" : "Slack";
+  }
   if (installation.externalChannelId) {
     return "Teams channel";
   }
@@ -950,6 +994,31 @@ function getCollaborationLabel(installation: TeamCollaborationInstallation) {
     return "Teams team";
   }
   return "Teams";
+}
+
+function getCollaborationMetadata(
+  installation: TeamCollaborationInstallation,
+): string {
+  if (installation.platform === "slack") {
+    return [
+      "Slack",
+      metaStr(installation.metadata, "teamDomain") ??
+        `Workspace ${installation.tenantId}`,
+      metaStr(installation.metadata, "channelName")
+        ? `#${metaStr(installation.metadata, "channelName")}`
+        : undefined,
+    ]
+      .filter(Boolean)
+      .join(" · ");
+  }
+
+  return [
+    "Microsoft Teams",
+    `Tenant ${installation.tenantId}`,
+    metaStr(installation.metadata, "frameContext"),
+  ]
+    .filter(Boolean)
+    .join(" · ");
 }
 
 function CollaborationInstallationRow({
@@ -971,10 +1040,7 @@ function CollaborationInstallationRow({
             {getCollaborationLabel(installation)}
           </p>
           <p className="text-xs text-slate-600 dark:text-slate-400">
-            Microsoft Teams · Tenant {installation.tenantId}
-            {metaStr(installation.metadata, "frameContext")
-              ? ` · ${metaStr(installation.metadata, "frameContext")}`
-              : ""}
+            {getCollaborationMetadata(installation)}
           </p>
           <p className="text-xs text-slate-400 dark:text-slate-500">
             Connected {new Date(installation.createdAt).toLocaleDateString()}

--- a/apps/auth-worker/src/controllers/team-integrations-controller.test.ts
+++ b/apps/auth-worker/src/controllers/team-integrations-controller.test.ts
@@ -5,6 +5,7 @@ import { signState } from "@sprintjam/utils";
 import {
   initiateTeamOAuthController,
   handleGithubTeamOAuthCallbackController,
+  handleSlackTeamOAuthCallbackController,
   listTeamIntegrationBoardsController,
   searchTeamIntegrationTicketsController,
 } from "./team-integrations-controller";
@@ -18,8 +19,10 @@ const mockWorkspaceIsOrganisationAdmin = vi.fn();
 const mockGetJiraCredentials = vi.fn();
 const mockGetGithubCredentials = vi.fn();
 const mockUpdateTokens = vi.fn();
+const mockSaveSlackCredentials = vi.fn();
 const mockFetchJiraBoards = vi.fn();
 const mockFetchGithubRepoIssues = vi.fn();
+const mockExchangeSlackOAuthCode = vi.fn();
 
 vi.mock("../lib/auth", () => ({
   authenticateRequest: (...args: unknown[]) => mockAuthenticateRequest(...args),
@@ -52,6 +55,10 @@ vi.mock("../repositories/team-integration-repository", () => ({
     updateTokens(...args: unknown[]) {
       return mockUpdateTokens(...args);
     }
+
+    saveSlackCredentials(...args: unknown[]) {
+      return mockSaveSlackCredentials(...args);
+    }
   },
 }));
 
@@ -61,6 +68,8 @@ vi.mock("@sprintjam/services", () => ({
     mockFetchGithubRepoIssues(...args),
   fetchGithubMilestones: vi.fn(),
   fetchGithubRepos: vi.fn(),
+  exchangeSlackOAuthCode: (...args: unknown[]) =>
+    mockExchangeSlackOAuthCode(...args),
   fetchJiraBoardIssues: vi.fn(),
   fetchJiraSprints: vi.fn(),
   fetchLinearCycles: vi.fn(),
@@ -172,6 +181,118 @@ describe("team integrations OAuth security", () => {
       }),
     );
     expect(JSON.stringify(signedState.data)).not.toContain("owner@example.com");
+  });
+
+  it("initiates Slack OAuth with app scopes and signed team state", async () => {
+    const repo = {
+      getTeamById: vi.fn().mockResolvedValue({
+        id: 7,
+        ownerId: 12,
+        organisationId: 5,
+        accessPolicy: "restricted",
+      }),
+      getUserById: vi.fn().mockResolvedValue({
+        id: 12,
+        email: "owner@example.com",
+        organisationId: 5,
+      }),
+      isOrganisationAdmin: vi.fn().mockResolvedValue(false),
+      getTeamMembership: vi
+        .fn()
+        .mockResolvedValue({ role: "admin", status: "active" }),
+      createAuthChallenge: vi.fn().mockResolvedValue(1),
+    };
+    mockAuthenticateRequest.mockResolvedValue({
+      userId: 12,
+      email: "owner@example.com",
+      repo,
+    });
+
+    const env = {
+      DB: {} as any,
+      SLACK_OAUTH_CLIENT_ID: "slack-id",
+      SLACK_OAUTH_CLIENT_SECRET: "slack-secret",
+      TOKEN_ENCRYPTION_SECRET: "token-secret",
+    } as AuthWorkerEnv;
+
+    const response = await initiateTeamOAuthController(
+      new Request("https://test/api/teams/7/integrations/slack/authorize", {
+        method: "POST",
+      }),
+      env,
+      7,
+      "slack",
+    );
+    const body = (await response.json()) as { authorizationUrl: string };
+    const authorizationUrl = new URL(body.authorizationUrl);
+
+    expect(response.status).toBe(200);
+    expect(authorizationUrl.origin).toBe("https://slack.com");
+    expect(authorizationUrl.pathname).toBe("/oauth/v2/authorize");
+    expect(authorizationUrl.searchParams.get("scope")).toBe(
+      "commands,chat:write,channels:read,groups:read",
+    );
+    expect(authorizationUrl.searchParams.get("state")).toBeTruthy();
+  });
+
+  it("stores Slack bot credentials from the OAuth callback", async () => {
+    const state = await signState(
+      {
+        teamId: 7,
+        userId: 12,
+        nonce: "slack-nonce",
+      },
+      "slack-secret",
+    );
+    const url = new URL(
+      `https://test/api/teams/integrations/slack/callback?code=abc&state=${encodeURIComponent(state)}`,
+    );
+    mockTeamIsAdmin.mockResolvedValue(true);
+    mockWorkspaceGetChallenge.mockResolvedValue({
+      id: 99,
+      userId: 12,
+      type: "oauth",
+      usedAt: null,
+      expiresAt: Date.now() + 60_000,
+      metadata: JSON.stringify({
+        teamId: 7,
+        authorizedBy: "owner@example.com",
+      }),
+    });
+    mockExchangeSlackOAuthCode.mockResolvedValue({
+      ok: true,
+      access_token: "xoxb-token",
+      token_type: "bot",
+      scope: "commands,chat:write,channels:read,groups:read",
+      bot_user_id: "U-BOT",
+      app_id: "A123",
+      team: { id: "T123", name: "Example" },
+      enterprise: null,
+      authed_user: { id: "U123" },
+    });
+
+    const response = await handleSlackTeamOAuthCallbackController(url, {
+      DB: {} as any,
+      SLACK_OAUTH_CLIENT_ID: "slack-id",
+      SLACK_OAUTH_CLIENT_SECRET: "slack-secret",
+      TOKEN_ENCRYPTION_SECRET: "token-secret",
+    } as AuthWorkerEnv);
+
+    expect(response.status).toBe(200);
+    expect(mockWorkspaceMarkChallengeUsed).toHaveBeenCalledWith(99);
+    expect(mockSaveSlackCredentials).toHaveBeenCalledWith(
+      expect.objectContaining({
+        teamId: 7,
+        accessToken: "xoxb-token",
+        tokenType: "bot",
+        authorizedBy: "owner@example.com",
+        slackTeamId: "T123",
+        slackTeamName: "Example",
+        slackBotUserId: "U-BOT",
+        slackAppId: "A123",
+        slackAuthedUserId: "U123",
+      }),
+    );
   });
 
   it("rejects callback when nonce challenge is missing", async () => {

--- a/apps/auth-worker/src/controllers/team-integrations-controller.ts
+++ b/apps/auth-worker/src/controllers/team-integrations-controller.ts
@@ -16,6 +16,7 @@ import {
   fetchLinearCycles,
   fetchLinearIssues,
   fetchLinearTeams,
+  exchangeSlackOAuthCode,
   findDefaultStoryPointsField,
   findDefaultSprintField,
   getLinearOrganization,
@@ -293,6 +294,17 @@ function getLinearOAuthConfig(env: AuthWorkerEnv) {
   return {
     clientId: env.LINEAR_OAUTH_CLIENT_ID,
     clientSecret: env.LINEAR_OAUTH_CLIENT_SECRET,
+  };
+}
+
+function getSlackOAuthConfig(env: AuthWorkerEnv) {
+  if (!env.SLACK_OAUTH_CLIENT_ID || !env.SLACK_OAUTH_CLIENT_SECRET) {
+    return null;
+  }
+
+  return {
+    clientId: env.SLACK_OAUTH_CLIENT_ID,
+    clientSecret: env.SLACK_OAUTH_CLIENT_SECRET,
   };
 }
 
@@ -798,6 +810,40 @@ export async function initiateTeamOAuthController(
       return jsonResponse({ authorizationUrl: authUrl.toString() });
     }
 
+    if (provider === "slack") {
+      const clientId = env.SLACK_OAUTH_CLIENT_ID;
+      const clientSecret = env.SLACK_OAUTH_CLIENT_SECRET;
+      const redirectUri =
+        env.SLACK_OAUTH_REDIRECT_URI ||
+        "https://sprintjam.co.uk/api/teams/integrations/slack/callback";
+
+      if (!clientId || !clientSecret) {
+        return jsonError(
+          "Slack OAuth not configured. Please contact administrator.",
+          500,
+        );
+      }
+
+      const state = await createSignedTeamOAuthState(
+        repo,
+        userId,
+        teamId,
+        user.email,
+        clientSecret,
+      );
+
+      const authUrl = new URL("https://slack.com/oauth/v2/authorize");
+      authUrl.searchParams.set("client_id", clientId);
+      authUrl.searchParams.set(
+        "scope",
+        "commands,chat:write,channels:read,groups:read",
+      );
+      authUrl.searchParams.set("redirect_uri", redirectUri);
+      authUrl.searchParams.set("state", state);
+
+      return jsonResponse({ authorizationUrl: authUrl.toString() });
+    }
+
     return jsonError("Unknown provider", 400);
   } catch (error) {
     console.error("Failed to initiate OAuth:", error);
@@ -1234,6 +1280,97 @@ export async function handleGithubTeamOAuthCallbackController(
     console.error("GitHub team OAuth callback error:", error);
     return oauthHtmlError(
       "An error occurred during GitHub authorization. Please try again.",
+      500,
+    );
+  }
+}
+
+export async function handleSlackTeamOAuthCallbackController(
+  url: URL,
+  env: AuthWorkerEnv,
+): Promise<Response> {
+  const code = url.searchParams.get("code");
+  const state = url.searchParams.get("state");
+  const error = url.searchParams.get("error");
+
+  if (error) return oauthHtmlError(error, 400);
+  if (!code || !state) return oauthHtmlError("Missing code or state", 400);
+
+  const oauthConfig = getSlackOAuthConfig(env);
+  const redirectUri =
+    env.SLACK_OAUTH_REDIRECT_URI ||
+    "https://sprintjam.co.uk/api/teams/integrations/slack/callback";
+
+  if (!oauthConfig) {
+    return oauthHtmlError("OAuth not configured", 500);
+  }
+
+  try {
+    const stateData = (await verifyState(
+      state,
+      oauthConfig.clientSecret,
+    )) as TeamOAuthState;
+    const { teamId, userId } = stateData;
+
+    const stillAdmin = await verifyTeamAdminAccess(env, teamId, userId);
+    if (!stillAdmin) {
+      return oauthHtmlError("Team access has changed. Please try again.", 403);
+    }
+
+    const oauthChallenge = await consumeOAuthNonce(env, stateData);
+    if (!oauthChallenge) {
+      return oauthHtmlError(
+        "Invalid OAuth state. Please retry connection.",
+        400,
+      );
+    }
+
+    const tokenData = await exchangeSlackOAuthCode({
+      clientId: oauthConfig.clientId,
+      clientSecret: oauthConfig.clientSecret,
+      code,
+      redirectUri,
+    });
+
+    if (!tokenData.ok || !tokenData.access_token) {
+      return oauthHtmlError(
+        tokenData.error ?? "Failed to exchange code for token",
+        400,
+      );
+    }
+
+    const integrationRepo = getIntegrationRepo(env);
+    await integrationRepo.saveSlackCredentials({
+      teamId,
+      accessToken: tokenData.access_token,
+      refreshToken: tokenData.refresh_token ?? null,
+      tokenType: tokenData.token_type ?? "bot",
+      expiresAt:
+        Date.now() + (tokenData.expires_in ?? 90 * 24 * 60 * 60) * 1000,
+      scope: tokenData.scope ?? null,
+      authorizedBy: oauthChallenge.authorizedBy,
+      slackTeamId: tokenData.team?.id ?? null,
+      slackTeamName: tokenData.team?.name ?? null,
+      slackEnterpriseId: tokenData.enterprise?.id ?? null,
+      slackEnterpriseName: tokenData.enterprise?.name ?? null,
+      slackBotUserId: tokenData.bot_user_id ?? null,
+      slackAppId: tokenData.app_id ?? null,
+      slackAuthedUserId: tokenData.authed_user?.id ?? null,
+    });
+
+    return oauthHtmlSuccess(
+      "Slack connected successfully. You can close this window.",
+    );
+  } catch (error) {
+    if (error instanceof Error && error.message === "Invalid state") {
+      return oauthHtmlError(
+        "Invalid OAuth state. Please retry connection.",
+        400,
+      );
+    }
+    console.error("Slack team OAuth callback error:", error);
+    return oauthHtmlError(
+      "An error occurred during Slack authorization. Please try again.",
       500,
     );
   }

--- a/apps/auth-worker/src/lib/collaboration.ts
+++ b/apps/auth-worker/src/lib/collaboration.ts
@@ -1,10 +1,14 @@
 import type { SaveTeamsCollaborationInstallationInput } from "@sprintjam/types";
+import {
+  boundedRecord,
+  optionalTrimmedString,
+} from "@sprintjam/utils";
 
 const MAX_CONTEXT_VALUE_LENGTH = 256;
 const MAX_DISPLAY_NAME_LENGTH = 120;
 const MAX_METADATA_LENGTH = 4096;
 
-type ParseResult =
+type TeamsParseResult =
   | { ok: true; value: SaveTeamsCollaborationInstallationInput }
   | { ok: false; error: string };
 
@@ -13,36 +17,6 @@ export class TeamsContextAlreadyLinkedError extends Error {
     super("Teams context is already linked to another team");
     this.name = "TeamsContextAlreadyLinkedError";
   }
-}
-
-function optionalString(value: unknown, maxLength = MAX_CONTEXT_VALUE_LENGTH) {
-  if (value === undefined || value === null) {
-    return null;
-  }
-
-  if (typeof value !== "string") {
-    return null;
-  }
-
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return null;
-  }
-
-  return trimmed.slice(0, maxLength);
-}
-
-function metadataObject(value: unknown): Record<string, unknown> {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return {};
-  }
-
-  const serialized = JSON.stringify(value);
-  if (serialized.length > MAX_METADATA_LENGTH) {
-    return {};
-  }
-
-  return value as Record<string, unknown>;
 }
 
 export function buildTeamsContextKey(
@@ -71,22 +45,42 @@ export function buildTeamsContextKey(
   return `${input.tenantId}:${scope}`;
 }
 
-export function parseTeamsInstallationPayload(raw: unknown): ParseResult {
+export function parseTeamsInstallationPayload(
+  raw: unknown,
+): TeamsParseResult {
   if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
     return { ok: false, error: "request body must be an object" };
   }
 
   const body = raw as Record<string, unknown>;
-  const tenantId = optionalString(body.tenantId);
+  const tenantId = optionalTrimmedString(
+    body.tenantId,
+    MAX_CONTEXT_VALUE_LENGTH,
+  );
   if (!tenantId) {
     return { ok: false, error: "tenantId is required" };
   }
 
-  const externalTeamId = optionalString(body.externalTeamId);
-  const externalChannelId = optionalString(body.externalChannelId);
-  const externalChatId = optionalString(body.externalChatId);
-  const externalMeetingId = optionalString(body.externalMeetingId);
-  const externalUserId = optionalString(body.externalUserId);
+  const externalTeamId = optionalTrimmedString(
+    body.externalTeamId,
+    MAX_CONTEXT_VALUE_LENGTH,
+  );
+  const externalChannelId = optionalTrimmedString(
+    body.externalChannelId,
+    MAX_CONTEXT_VALUE_LENGTH,
+  );
+  const externalChatId = optionalTrimmedString(
+    body.externalChatId,
+    MAX_CONTEXT_VALUE_LENGTH,
+  );
+  const externalMeetingId = optionalTrimmedString(
+    body.externalMeetingId,
+    MAX_CONTEXT_VALUE_LENGTH,
+  );
+  const externalUserId = optionalTrimmedString(
+    body.externalUserId,
+    MAX_CONTEXT_VALUE_LENGTH,
+  );
 
   if (
     !externalTeamId &&
@@ -111,8 +105,11 @@ export function parseTeamsInstallationPayload(raw: unknown): ParseResult {
       externalChatId,
       externalMeetingId,
       externalUserId,
-      displayName: optionalString(body.displayName, MAX_DISPLAY_NAME_LENGTH),
-      metadata: metadataObject(body.metadata),
+      displayName: optionalTrimmedString(
+        body.displayName,
+        MAX_DISPLAY_NAME_LENGTH,
+      ),
+      metadata: boundedRecord(body.metadata, MAX_METADATA_LENGTH),
     },
   };
 }

--- a/apps/auth-worker/src/repositories/team-integration-repository.ts
+++ b/apps/auth-worker/src/repositories/team-integration-repository.ts
@@ -8,6 +8,7 @@ import type {
   JiraOAuthCredentials,
   LinearOAuthCredentials,
   OAuthProvider,
+  SlackOAuthCredentials,
 } from "@sprintjam/types";
 import { safeJsonParse, TokenCipher } from "@sprintjam/utils";
 
@@ -32,6 +33,16 @@ type GithubMetadata = {
   githubUserEmail?: string | null;
   defaultOwner?: string | null;
   defaultRepo?: string | null;
+};
+
+type SlackMetadata = {
+  slackTeamId?: string | null;
+  slackTeamName?: string | null;
+  slackEnterpriseId?: string | null;
+  slackEnterpriseName?: string | null;
+  slackBotUserId?: string | null;
+  slackAppId?: string | null;
+  slackAuthedUserId?: string | null;
 };
 
 export class TeamIntegrationRepository {
@@ -355,6 +366,65 @@ export class TeamIntegrationRepository {
         defaultOwner: params.defaultOwner,
         defaultRepo: params.defaultRepo,
       } satisfies GithubMetadata),
+    });
+  }
+
+  async getSlackCredentials(
+    teamId: number,
+  ): Promise<SlackOAuthCredentials | null> {
+    const result = await this.getCredentials<SlackMetadata>(teamId, "slack");
+    if (!result) return null;
+
+    return {
+      ...result.core,
+      roomKey: `team:${teamId}`,
+      id: 0,
+      createdAt: 0,
+      updatedAt: 0,
+      slackTeamId: result.metadata.slackTeamId ?? null,
+      slackTeamName: result.metadata.slackTeamName ?? null,
+      slackEnterpriseId: result.metadata.slackEnterpriseId ?? null,
+      slackEnterpriseName: result.metadata.slackEnterpriseName ?? null,
+      slackBotUserId: result.metadata.slackBotUserId ?? null,
+      slackAppId: result.metadata.slackAppId ?? null,
+      slackAuthedUserId: result.metadata.slackAuthedUserId ?? null,
+    };
+  }
+
+  async saveSlackCredentials(params: {
+    teamId: number;
+    accessToken: string;
+    refreshToken: string | null;
+    tokenType: string;
+    expiresAt: number;
+    scope: string | null;
+    authorizedBy: string;
+    slackTeamId: string | null;
+    slackTeamName: string | null;
+    slackEnterpriseId: string | null;
+    slackEnterpriseName: string | null;
+    slackBotUserId: string | null;
+    slackAppId: string | null;
+    slackAuthedUserId: string | null;
+  }): Promise<void> {
+    await this.saveIntegration({
+      teamId: params.teamId,
+      provider: "slack",
+      accessToken: params.accessToken,
+      refreshToken: params.refreshToken,
+      tokenType: params.tokenType,
+      expiresAt: params.expiresAt,
+      scope: params.scope,
+      authorizedBy: params.authorizedBy,
+      metadata: JSON.stringify({
+        slackTeamId: params.slackTeamId,
+        slackTeamName: params.slackTeamName,
+        slackEnterpriseId: params.slackEnterpriseId,
+        slackEnterpriseName: params.slackEnterpriseName,
+        slackBotUserId: params.slackBotUserId,
+        slackAppId: params.slackAppId,
+        slackAuthedUserId: params.slackAuthedUserId,
+      } satisfies SlackMetadata),
     });
   }
 }

--- a/apps/auth-worker/src/routes/router.ts
+++ b/apps/auth-worker/src/routes/router.ts
@@ -59,6 +59,7 @@ import {
   handleJiraTeamOAuthCallbackController,
   handleLinearTeamOAuthCallbackController,
   handleGithubTeamOAuthCallbackController,
+  handleSlackTeamOAuthCallbackController,
   revokeTeamIntegrationController,
   getTeamCredentialsInternalController,
   refreshTeamCredentialsInternalController,
@@ -492,7 +493,7 @@ const ROUTES: RouteDefinition[] = [
   },
   {
     method: "POST",
-    pattern: /^teams\/(\d+)\/integrations\/(jira|linear|github)\/authorize$/,
+    pattern: /^teams\/(\d+)\/integrations\/(jira|linear|github|slack)\/authorize$/,
     handler: (request, env, params) => {
       const teamIdResult = requireNumberParam(params[0], "teamId");
       if (!teamIdResult.ok) return teamIdResult.response;
@@ -500,14 +501,14 @@ const ROUTES: RouteDefinition[] = [
         request,
         env,
         teamIdResult.value,
-        params[1] as "jira" | "linear" | "github",
+        params[1] as "jira" | "linear" | "github" | "slack",
       );
     },
     paramTypes: ["number", "string"],
   },
   {
     method: "GET",
-    pattern: /^teams\/(\d+)\/integrations\/(jira|linear|github)\/status$/,
+    pattern: /^teams\/(\d+)\/integrations\/(jira|linear|github|slack)\/status$/,
     handler: (request, env, params) => {
       const teamIdResult = requireNumberParam(params[0], "teamId");
       if (!teamIdResult.ok) return teamIdResult.response;
@@ -515,7 +516,7 @@ const ROUTES: RouteDefinition[] = [
         request,
         env,
         teamIdResult.value,
-        params[1] as "jira" | "linear" | "github",
+        params[1] as "jira" | "linear" | "github" | "slack",
       );
     },
     paramTypes: ["number", "string"],
@@ -567,7 +568,7 @@ const ROUTES: RouteDefinition[] = [
   },
   {
     method: "DELETE",
-    pattern: /^teams\/(\d+)\/integrations\/(jira|linear|github)$/,
+    pattern: /^teams\/(\d+)\/integrations\/(jira|linear|github|slack)$/,
     handler: (request, env, params) => {
       const teamIdResult = requireNumberParam(params[0], "teamId");
       if (!teamIdResult.ok) return teamIdResult.response;
@@ -575,7 +576,7 @@ const ROUTES: RouteDefinition[] = [
         request,
         env,
         teamIdResult.value,
-        params[1] as "jira" | "linear" | "github",
+        params[1] as "jira" | "linear" | "github" | "slack",
       );
     },
     paramTypes: ["number", "string"],
@@ -622,6 +623,21 @@ const ROUTES: RouteDefinition[] = [
         if (!success) return jsonError("Rate limit exceeded", 429);
       }
       return handleGithubTeamOAuthCallbackController(new URL(request.url), env);
+    },
+    paramTypes: ["none"],
+  },
+  {
+    method: "GET",
+    pattern: /^teams\/integrations\/slack\/callback$/,
+    handler: async (request, env) => {
+      if (env.IP_RATE_LIMITER) {
+        const ip = request.headers.get("cf-connecting-ip") ?? "unknown";
+        const { success } = await env.IP_RATE_LIMITER.limit({
+          key: `oauth-callback:${ip}`,
+        });
+        if (!success) return jsonError("Rate limit exceeded", 429);
+      }
+      return handleSlackTeamOAuthCallbackController(new URL(request.url), env);
     },
     paramTypes: ["none"],
   },

--- a/packages/db/src/d1/schemas/team-integrations.ts
+++ b/packages/db/src/d1/schemas/team-integrations.ts
@@ -10,7 +10,7 @@ export const teamIntegrations = sqliteTable(
       .notNull()
       .references(() => teams.id, { onDelete: "cascade" }),
     provider: text("provider", {
-      enum: ["jira", "linear", "github"],
+      enum: ["jira", "linear", "github", "slack"],
     }).notNull(),
     accessToken: text("access_token").notNull(),
     refreshToken: text("refresh_token"),

--- a/packages/services/src/index.ts
+++ b/packages/services/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./jira-service";
 export * from "./linear-service";
 export * from "./github-service";
+export * from "./slack-service";
 export * from "./email";

--- a/packages/services/src/slack-service.ts
+++ b/packages/services/src/slack-service.ts
@@ -1,0 +1,48 @@
+export interface SlackOAuthAccessResponse {
+  ok: boolean;
+  access_token?: string;
+  token_type?: string;
+  scope?: string;
+  bot_user_id?: string;
+  app_id?: string;
+  expires_in?: number;
+  refresh_token?: string;
+  team?: {
+    id?: string;
+    name?: string;
+  } | null;
+  enterprise?: {
+    id?: string;
+    name?: string;
+  } | null;
+  authed_user?: {
+    id?: string;
+  } | null;
+  error?: string;
+}
+
+export async function exchangeSlackOAuthCode(params: {
+  clientId: string;
+  clientSecret: string;
+  code: string;
+  redirectUri: string;
+}): Promise<SlackOAuthAccessResponse> {
+  const body = new URLSearchParams({
+    client_id: params.clientId,
+    client_secret: params.clientSecret,
+    code: params.code,
+    redirect_uri: params.redirectUri,
+  });
+
+  const response = await fetch("https://slack.com/api/oauth.v2.access", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Slack OAuth token exchange failed: ${response.status}`);
+  }
+
+  return response.json<SlackOAuthAccessResponse>();
+}

--- a/packages/types/src/env.ts
+++ b/packages/types/src/env.ts
@@ -72,6 +72,9 @@ export interface AuthWorkerEnv extends BaseEnv {
   GITHUB_OAUTH_CLIENT_ID?: string;
   GITHUB_OAUTH_CLIENT_SECRET?: string;
   GITHUB_OAUTH_REDIRECT_URI?: string;
+  SLACK_OAUTH_CLIENT_ID?: string;
+  SLACK_OAUTH_CLIENT_SECRET?: string;
+  SLACK_OAUTH_REDIRECT_URI?: string;
   SEND_EMAIL: SendEmail;
 }
 

--- a/packages/types/src/external.ts
+++ b/packages/types/src/external.ts
@@ -3,7 +3,7 @@
  */
 import type { OauthCredentialsItem as DbOauthCredentialsItem } from "@sprintjam/db";
 
-export type OAuthProvider = "jira" | "linear" | "github";
+export type OAuthProvider = "jira" | "linear" | "github" | "slack";
 
 export interface ExternalTicketMetadata {
   id?: string;
@@ -122,6 +122,16 @@ export interface GithubOAuthCredentials extends BaseOAuthCredentials {
   defaultRepo: string | null;
 }
 
+export interface SlackOAuthCredentials extends BaseOAuthCredentials {
+  slackTeamId: string | null;
+  slackTeamName: string | null;
+  slackEnterpriseId: string | null;
+  slackEnterpriseName: string | null;
+  slackBotUserId: string | null;
+  slackAppId: string | null;
+  slackAuthedUserId: string | null;
+}
+
 export interface GithubIssue {
   id: string;
   key: string;
@@ -159,6 +169,14 @@ export interface GithubOAuthStatus extends OAuthStatusBase {
   githubUserEmail?: string | null;
   defaultOwner?: string | null;
   defaultRepo?: string | null;
+}
+
+export interface SlackOAuthStatus extends OAuthStatusBase {
+  slackTeamId?: string | null;
+  slackTeamName?: string | null;
+  slackEnterpriseId?: string | null;
+  slackBotUserId?: string | null;
+  slackAppId?: string | null;
 }
 
 export interface JiraFieldOption {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -19,3 +19,5 @@ export * from "./lib/stats-client";
 export * from "./bot-check";
 export * from "./escape";
 export * from "./random";
+export * from "./object";
+export * from "./string";

--- a/packages/utils/src/object.test.ts
+++ b/packages/utils/src/object.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { boundedRecord } from "./object";
+
+describe("boundedRecord", () => {
+  it("returns objects that fit within the serialized length limit", () => {
+    expect(boundedRecord({ source: "slack" }, 32)).toEqual({
+      source: "slack",
+    });
+  });
+
+  it("returns an empty object for non-records and oversized objects", () => {
+    expect(boundedRecord(null, 32)).toEqual({});
+    expect(boundedRecord(["source"], 32)).toEqual({});
+    expect(boundedRecord({ value: "x".repeat(64) }, 32)).toEqual({});
+  });
+});

--- a/packages/utils/src/object.ts
+++ b/packages/utils/src/object.ts
@@ -1,0 +1,15 @@
+export function boundedRecord(
+  value: unknown,
+  maxSerializedLength: number,
+): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return {};
+  }
+
+  const serialized = JSON.stringify(value);
+  if (serialized.length > maxSerializedLength) {
+    return {};
+  }
+
+  return value as Record<string, unknown>;
+}

--- a/packages/utils/src/string.test.ts
+++ b/packages/utils/src/string.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+
+import { optionalTrimmedString } from "./string";
+
+describe("optionalTrimmedString", () => {
+  it("trims strings and applies the maximum length", () => {
+    expect(optionalTrimmedString("  channel-name  ", 7)).toBe("channel");
+  });
+
+  it("returns null for empty and non-string values", () => {
+    expect(optionalTrimmedString("   ", 10)).toBeNull();
+    expect(optionalTrimmedString(123, 10)).toBeNull();
+  });
+});

--- a/packages/utils/src/string.ts
+++ b/packages/utils/src/string.ts
@@ -1,0 +1,19 @@
+export function optionalTrimmedString(
+  value: unknown,
+  maxLength: number,
+): string | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  return trimmed.slice(0, maxLength);
+}


### PR DESCRIPTION
## Summary
- Add Slack as a workspace-managed integration alongside the existing team OAuth providers.
- Store Slack installation metadata and bot credentials through the shared team integration flow.
- Update the team settings UI and marketing integrations page to show Slack alongside the other supported chat tools.
- Extract generic parsing and validation helpers into shared utility modules.

## Testing
- Added controller and repository coverage for Slack OAuth initiation and callback handling.
- Added utility tests for the shared string and object helpers.
- Not run locally in this environment because workspace dependencies are unavailable.