### PR TITLE
Gracefully handle auth worker failures in loadWorkspaceAuthProfile and add tests

### DIFF
--- a/apps/app/src/lib/workspace-loaders.test.ts
+++ b/apps/app/src/lib/workspace-loaders.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { loadWorkspaceAuthProfile } from "@/lib/workspace-loaders";
+import type { WorkerLoaderArgs } from "@/lib/worker-utils";
+
+const makeArgs = (response: Response): WorkerLoaderArgs =>
+  ({
+    request: new Request("https://sprintjam.test/room/ROOM1"),
+    context: {
+      cloudflare: {
+        env: {
+          AUTH_WORKER: {
+            fetch: vi.fn().mockResolvedValue(response),
+          },
+        },
+      },
+    },
+  }) as unknown as WorkerLoaderArgs;
+
+describe("loadWorkspaceAuthProfile", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns null instead of throwing when the auth worker errors", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const args = makeArgs(
+      new Response("Auth worker unavailable", {
+        status: 500,
+        statusText: "Internal Server Error",
+      }),
+    );
+
+    await expect(loadWorkspaceAuthProfile(args)).resolves.toBeNull();
+    expect(consoleError).toHaveBeenCalledWith(
+      "Failed to load initial workspace auth profile",
+      expect.any(Response),
+    );
+  });
+
+  it("still returns authenticated profile data when the auth worker succeeds", async () => {
+    const profile = {
+      user: { id: 1, name: "Ada" },
+      teams: [],
+    };
+    const args = makeArgs(
+      new Response(JSON.stringify(profile), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await expect(loadWorkspaceAuthProfile(args)).resolves.toEqual(profile);
+  });
+});

--- a/apps/app/src/lib/workspace-loaders.ts
+++ b/apps/app/src/lib/workspace-loaders.ts
@@ -67,7 +67,12 @@ async function loadFromStatsWorker<T>(
 export async function loadWorkspaceAuthProfile(
   args: WorkerLoaderArgs,
 ): Promise<WorkspaceAuthProfile | null> {
-  return loadFromAuthWorker<WorkspaceAuthProfile>(args, "/api/auth/me");
+  try {
+    return await loadFromAuthWorker<WorkspaceAuthProfile>(args, "/api/auth/me");
+  } catch (error) {
+    console.error("Failed to load initial workspace auth profile", error);
+    return null;
+  }
 }
 
 export async function loadWorkspaceProfile(

--- a/apps/app/src/root.tsx
+++ b/apps/app/src/root.tsx
@@ -71,7 +71,10 @@ function loadInitialServerDefaults(): ServerDefaults {
 export function loader({ request, context }: LoaderFunctionArgs) {
   return {
     initialServerDefaults: loadInitialServerDefaults(),
-    initialWorkspaceProfile: loadWorkspaceAuthProfile({ request, context }),
+    initialWorkspaceProfile: loadWorkspaceAuthProfile({
+      request,
+      context,
+    }),
   };
 }
 


### PR DESCRIPTION
### Motivation
- Prevent the app loader from throwing when the auth worker is unavailable by failing gracefully and returning `null` for initial workspace auth data.
- Add test coverage to ensure both error and success responses from the auth worker behave as expected.

### Description
- Wrap `loadWorkspaceAuthProfile` in a `try/catch` that logs the error via `console.error` and returns `null` on failure.
- Add unit tests (`apps/app/src/lib/workspace-loaders.test.ts`) that assert `loadWorkspaceAuthProfile` returns `null` on a 500 response and returns the parsed profile on a 200 response.
- Apply a small formatting change to the `loader` call site in `apps/app/src/root.tsx` to pass `request` and `context` as an object across multiple lines.

### Testing
- Added `workspace-loaders.test.ts` which exercises error and success cases for `loadWorkspaceAuthProfile` using `vitest` and mocked worker `fetch` responses, and the tests passed locally. 
- Ran the test suite via `vitest` which completed successfully without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc3e6d5f90832a9e4ba07ffe8e64a2)