### PR TITLE
Fix auth loader failure handling and server-defaults loading

### DIFF
--- a/apps/app/src/context/ServerDefaultsContext.test.tsx
+++ b/apps/app/src/context/ServerDefaultsContext.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it } from "vitest";
 import { getServerDefaults } from "@sprintjam/utils";
 
 import {
@@ -10,16 +10,6 @@ import {
   useServerDefaults,
 } from "./ServerDefaultsContext";
 import type { ServerDefaults } from "@/types";
-
-const mocks = vi.hoisted(() => ({
-  state: "idle" as "idle" | "loading" | "submitting",
-}));
-
-vi.mock("react-router", () => ({
-  useRevalidator: () => ({
-    state: mocks.state,
-  }),
-}));
 
 function DefaultsProbe() {
   const { serverDefaults, isLoadingDefaults } = useServerDefaults();
@@ -43,10 +33,6 @@ function getTestServerDefaults(): ServerDefaults {
 }
 
 describe("ServerDefaultsProvider", () => {
-  beforeEach(() => {
-    mocks.state = "idle";
-  });
-
   it("exposes loader defaults through context", () => {
     const defaults = getTestServerDefaults();
 
@@ -62,9 +48,8 @@ describe("ServerDefaultsProvider", () => {
     expect(screen.getByTestId("loading").textContent).toBe("false");
   });
 
-  it("tracks route revalidation while defaults are refreshed by the loader", () => {
+  it("does not report unrelated route revalidation as server-defaults loading", () => {
     const defaults = getTestServerDefaults();
-    mocks.state = "loading";
 
     render(
       <ServerDefaultsProvider defaults={defaults}>
@@ -72,6 +57,6 @@ describe("ServerDefaultsProvider", () => {
       </ServerDefaultsProvider>,
     );
 
-    expect(screen.getByTestId("loading").textContent).toBe("true");
+    expect(screen.getByTestId("loading").textContent).toBe("false");
   });
 });

--- a/apps/app/src/context/ServerDefaultsContext.tsx
+++ b/apps/app/src/context/ServerDefaultsContext.tsx
@@ -1,5 +1,4 @@
 import { createContext, useContext, useMemo, type ReactNode } from "react";
-import { useRevalidator } from "react-router";
 
 import type { ServerDefaults } from "@/types";
 import { cloneServerDefaults } from "@/utils/settings";
@@ -20,7 +19,6 @@ export function ServerDefaultsProvider({
   children: ReactNode;
   defaults: ServerDefaults;
 }) {
-  const revalidator = useRevalidator();
   const serverDefaults = useMemo(
     () => cloneServerDefaults(defaults),
     [defaults],
@@ -29,9 +27,9 @@ export function ServerDefaultsProvider({
   const value = useMemo<ServerDefaultsContextValue>(
     () => ({
       serverDefaults,
-      isLoadingDefaults: revalidator.state !== "idle",
+      isLoadingDefaults: false,
     }),
-    [revalidator.state, serverDefaults],
+    [serverDefaults],
   );
 
   return (

--- a/apps/app/src/lib/workspace-loaders.test.ts
+++ b/apps/app/src/lib/workspace-loaders.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { loadWorkspaceAuthProfile } from "@/lib/workspace-loaders";
+import {
+  loadInitialWorkspaceAuthProfile,
+  loadWorkspaceAuthProfile,
+} from "@/lib/workspace-loaders";
 import type { WorkerLoaderArgs } from "@/lib/worker-utils";
 
 const makeArgs = (response: Response): WorkerLoaderArgs =>
@@ -22,7 +25,7 @@ describe("loadWorkspaceAuthProfile", () => {
     vi.restoreAllMocks();
   });
 
-  it("returns null instead of throwing when the auth worker errors", async () => {
+  it("throws when the auth worker errors", async () => {
     const consoleError = vi
       .spyOn(console, "error")
       .mockImplementation(() => {});
@@ -33,11 +36,10 @@ describe("loadWorkspaceAuthProfile", () => {
       }),
     );
 
-    await expect(loadWorkspaceAuthProfile(args)).resolves.toBeNull();
-    expect(consoleError).toHaveBeenCalledWith(
-      "Failed to load initial workspace auth profile",
-      expect.any(Response),
-    );
+    await expect(loadWorkspaceAuthProfile(args)).rejects.toMatchObject({
+      status: 500,
+    });
+    expect(consoleError).not.toHaveBeenCalled();
   });
 
   it("still returns authenticated profile data when the auth worker succeeds", async () => {
@@ -53,5 +55,66 @@ describe("loadWorkspaceAuthProfile", () => {
     );
 
     await expect(loadWorkspaceAuthProfile(args)).resolves.toEqual(profile);
+  });
+
+  it("throws when the auth worker returns malformed JSON", async () => {
+    const args = makeArgs(
+      new Response("not json", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await expect(loadWorkspaceAuthProfile(args)).rejects.toBeInstanceOf(
+      SyntaxError,
+    );
+  });
+
+  it("returns null for unauthenticated auth responses", async () => {
+    const args = makeArgs(new Response("Unauthorised", { status: 401 }));
+
+    await expect(loadWorkspaceAuthProfile(args)).resolves.toBeNull();
+  });
+});
+
+describe("loadInitialWorkspaceAuthProfile", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns null instead of throwing when the initial auth profile load errors", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const args = makeArgs(
+      new Response("Auth worker unavailable", {
+        status: 500,
+        statusText: "Internal Server Error",
+      }),
+    );
+
+    await expect(loadInitialWorkspaceAuthProfile(args)).resolves.toBeNull();
+    expect(consoleError).toHaveBeenCalledWith(
+      "Failed to load initial workspace auth profile",
+      expect.any(Response),
+    );
+  });
+
+  it("returns null instead of throwing when the initial auth profile is malformed", async () => {
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const args = makeArgs(
+      new Response("not json", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    await expect(loadInitialWorkspaceAuthProfile(args)).resolves.toBeNull();
+    expect(consoleError).toHaveBeenCalledWith(
+      "Failed to load initial workspace auth profile",
+      expect.any(SyntaxError),
+    );
   });
 });

--- a/apps/app/src/lib/workspace-loaders.ts
+++ b/apps/app/src/lib/workspace-loaders.ts
@@ -67,8 +67,14 @@ async function loadFromStatsWorker<T>(
 export async function loadWorkspaceAuthProfile(
   args: WorkerLoaderArgs,
 ): Promise<WorkspaceAuthProfile | null> {
+  return loadFromAuthWorker<WorkspaceAuthProfile>(args, "/api/auth/me");
+}
+
+export async function loadInitialWorkspaceAuthProfile(
+  args: WorkerLoaderArgs,
+): Promise<WorkspaceAuthProfile | null> {
   try {
-    return await loadFromAuthWorker<WorkspaceAuthProfile>(args, "/api/auth/me");
+    return await loadWorkspaceAuthProfile(args);
   } catch (error) {
     console.error("Failed to load initial workspace auth profile", error);
     return null;

--- a/apps/app/src/root.tsx
+++ b/apps/app/src/root.tsx
@@ -17,7 +17,7 @@ import { WorkspaceAuthProvider } from "@/context/WorkspaceAuthContext";
 import { AppToastProvider } from "@/components/ui";
 import { useCurrentRoute } from "@/hooks/useCurrentRoute";
 import { queryClient } from "@/lib/query-client";
-import { loadWorkspaceAuthProfile } from "@/lib/workspace-loaders";
+import { loadInitialWorkspaceAuthProfile } from "@/lib/workspace-loaders";
 import { ThemeProvider } from "@/lib/theme-context";
 import type { ServerDefaults } from "@/types";
 
@@ -71,7 +71,7 @@ function loadInitialServerDefaults(): ServerDefaults {
 export function loader({ request, context }: LoaderFunctionArgs) {
   return {
     initialServerDefaults: loadInitialServerDefaults(),
-    initialWorkspaceProfile: loadWorkspaceAuthProfile({
+    initialWorkspaceProfile: loadInitialWorkspaceAuthProfile({
       request,
       context,
     }),


### PR DESCRIPTION
### Motivation
- Room pages could be blocked in a perpetual loading state when unrelated loader work (auth / workspace) caused server-defaults revalidation or when the shared auth helper swallowed auth-worker 5xx/malformed responses.
- Route loaders should surface auth-worker failures to their `ErrorBoundary`, while the root app bootstrap should still degrade gracefully when the initial profile lookup fails.

### Description
- Add a root-only helper `loadInitialWorkspaceAuthProfile` that logs failures and returns `null` so the root bootstrap can degrade without throwing. (`apps/app/src/lib/workspace-loaders.ts`)
- Keep `loadWorkspaceAuthProfile` strict (it now throws on 5xx or malformed `/api/auth/me` responses) so workspace route loaders surface errors to their `ErrorBoundary`. (`apps/app/src/lib/workspace-loaders.ts`)
- Update the root loader to call `loadInitialWorkspaceAuthProfile` instead of the strict loader so only the initial root load is tolerant. (`apps/app/src/root.tsx`)
- Stop tying `isLoadingDefaults` to unrelated route revalidation by removing `useRevalidator` from `ServerDefaultsContext` and marking `isLoadingDefaults` based on the provided defaults; this prevents unrelated loader activity from blocking room reconnect logic. (`apps/app/src/context/ServerDefaultsContext.tsx`)
- Update and extend tests to cover strict route-loader failure behavior, graceful initial-profile handling, malformed auth JSON handling, unauthenticated responses, and the server-defaults loading expectation. (`apps/app/src/lib/workspace-loaders.test.ts`, `apps/app/src/context/ServerDefaultsContext.test.tsx`)

### Testing
- Ran targeted tests: `pnpm --filter @sprintjam/app test -- workspace-loaders.test.ts ServerDefaultsContext.test.tsx` and broader app tests; all updated tests passed (final run: 56 test files, 277 tests across suite passed).
- Ran type checking with `pnpm --filter @sprintjam/app typecheck`, which succeeded.
- Ran linting (`pnpm run lint`) which succeeded for the repo; note the package-level lint script for `@sprintjam/app` is not defined.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc6a8f89f0832a8bb7c69cdf69344c)